### PR TITLE
fix: READMEに定義されている drive.file OAuth スコープを追加

### DIFF
--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -82,7 +82,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     },
     onError: clearAuth,
     scope:
-      "openid email profile https://www.googleapis.com/auth/drive.appdata",
+      "openid email profile https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.appdata",
   });
 
   const logout = useCallback(() => {


### PR DESCRIPTION
## 概要

README では Google Drive へのアクセスに 2 つの OAuth スコープが定義されていますが、実装に `drive.file` が欠落していました。

## 問題

| スコープ | 用途 | 実装状況 |
|---------|------|---------|
| `drive.file` | 手帳画像フォルダ（可視）へのアクセス | ❌ 欠落 |
| `drive.appdata` | appDataFolder へのアクセス | ✅ |

`drive.file` がないと、マイドライブに「手帳スキャン」フォルダを作成・管理できず、撮影画像やスキャナ画像の保存が一切動作しません。

## 変更内容

- `src/lib/auth-context.tsx` の OAuth スコープに `https://www.googleapis.com/auth/drive.file` を追加

```diff
- scope: "openid email profile https://www.googleapis.com/auth/drive.appdata",
+ scope: "openid email profile https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.appdata",
```

## 確認

- [x] TypeScript 型チェック (`tsc --noEmit`) パス

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@haoling can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6a62f041-ffed-42aa-9a10-aac3ad1dfd2e)