### PR TITLE
段落分割モジュールを実装 (#17)

### DIFF
--- a/public/opencv-worker.js
+++ b/public/opencv-worker.js
@@ -345,6 +345,197 @@ function detectDocumentCorners(imageData) {
 }
 
 // ---------------------------------------------------------------------------
+// 段落境界検出（Paragraph Split Detection）
+// ---------------------------------------------------------------------------
+
+/**
+ * OpenCV.js を使用して水平罫線と余白から段落境界を検出する。
+ *
+ * アルゴリズム:
+ * 1. グレースケール → ガウシアンブラー
+ * 2. Canny エッジ検出
+ * 3. HoughLinesP で線分を検出
+ * 4. 水平に近い線分（角度±15°以内）を抽出
+ * 5. Y座標が近い線分をクラスタリングして代表Y座標を算出
+ * 6. 行ごとのピクセル投射密度を計算して、余白（テキスト密度の谷）を検出
+ * 7. 罫線のY座標と余白のY座標を統合して段落境界のY座標配列を生成
+ *
+ * @param {{ data: Uint8ClampedArray, width: number, height: number }} imageData
+ * @param {{ minLineLength?: number, maxAngleDeg?: number, whitespaceThreshold?: number }} options
+ * @returns {{ splitYs: number[] }}
+ */
+function detectParagraphBoundaries(imageData, options = {}) {
+  const {
+    minLineLength = imageData.width * 0.15,
+    maxAngleDeg = 15,
+    whitespaceThreshold = 0.03,
+  } = options;
+
+  const { data, width: srcWidth, height: srcHeight } = imageData;
+  const srcMat = cv.matFromImageData({ data, width: srcWidth, height: srcHeight });
+
+  let grayMat = null;
+  let blurMat = null;
+  let edgeMat = null;
+  let linesMat = null;
+  let projection = null;
+
+  try {
+    // グレースケール
+    grayMat = new cv.Mat();
+    cv.cvtColor(srcMat, grayMat, cv.COLOR_RGBA2GRAY);
+
+    // ガウシアンブラー
+    blurMat = new cv.Mat();
+    const kSize = Math.min(5, Math.max(3, Math.round(Math.min(srcWidth, srcHeight) / 200)));
+    const k = kSize % 2 === 0 ? kSize + 1 : kSize;
+    cv.GaussianBlur(grayMat, blurMat, new cv.Size(k, k), 0);
+
+    // Canny エッジ検出
+    edgeMat = new cv.Mat();
+    cv.Canny(blurMat, edgeMat, 50, 150);
+
+    // HoughLinesP で線分検出
+    linesMat = new cv.Mat();
+    const minLinePx = Math.max(20, Math.round(minLineLength));
+    cv.HoughLinesP(edgeMat, linesMat, 1, Math.PI / 180, 50, minLinePx, 10);
+
+    // 水平に近い線分を抽出（角度±maxAngleDeg度以内）
+    const maxAngleRad = (maxAngleDeg * Math.PI) / 180;
+    const lineYs = [];
+    for (let i = 0; i < linesMat.rows; i++) {
+      const x1 = linesMat.data32S[i * 4];
+      const y1 = linesMat.data32S[i * 4 + 1];
+      const x2 = linesMat.data32S[i * 4 + 2];
+      const y2 = linesMat.data32S[i * 4 + 3];
+
+      const dx = x2 - x1;
+      const dy = y2 - y1;
+      const length = Math.hypot(dx, dy);
+      if (length < 1) continue;
+
+      const angle = Math.abs(Math.atan2(dy, dx));
+      // 水平: angle ≈ 0 または angle ≈ π
+      if (angle <= maxAngleRad || angle >= Math.PI - maxAngleRad) {
+        const avgY = Math.round((y1 + y2) / 2);
+        lineYs.push(avgY);
+      }
+    }
+
+    // Y座標のクラスタリング（近いY座標をまとめる）
+    const CLUSTER_DISTANCE = Math.max(5, Math.round(srcHeight * 0.008));
+    const sorted = [...lineYs].sort((a, b) => a - b);
+    const lineClusters = [];
+    let clusterCenter = sorted.length > 0 ? sorted[0] : 0;
+    let clusterCount = 0;
+    for (const y of sorted) {
+      if (Math.abs(y - clusterCenter) <= CLUSTER_DISTANCE) {
+        clusterCenter = Math.round((clusterCenter * clusterCount + y) / (clusterCount + 1));
+        clusterCount++;
+      } else {
+        if (clusterCount >= 1) lineClusters.push(clusterCenter);
+        clusterCenter = y;
+        clusterCount = 1;
+      }
+    }
+    if (clusterCount >= 1) lineClusters.push(clusterCenter);
+
+    // 行投影密度（水平方向のピクセル数を各行でカウント）
+    projection = new cv.Mat();
+    cv.reduce(edgeMat, projection, 1, cv.REDUCE_SUM, cv.CV_32S);
+
+    // 投影値から移動平均を計算してノイズを平滑化
+    const WINDOW_SIZE = Math.max(3, Math.round(srcHeight * 0.01));
+    const projData = projection.data32S;
+    const smoothed = new Float32Array(srcHeight);
+    for (let y = 0; y < srcHeight; y++) {
+      let sum = 0;
+      let count = 0;
+      const halfW = Math.floor(WINDOW_SIZE / 2);
+      for (let dy = -halfW; dy <= halfW; dy++) {
+        const yy = y + dy;
+        if (yy >= 0 && yy < srcHeight) {
+          sum += projData[yy];
+          count++;
+        }
+      }
+      smoothed[y] = sum / count;
+    }
+
+    // 最大投影値で正規化
+    let maxProj = 0;
+    for (let y = 0; y < srcHeight; y++) {
+      if (smoothed[y] > maxProj) maxProj = smoothed[y];
+    }
+    const normalized = maxProj > 0
+      ? smoothed.map((v) => v / maxProj)
+      : new Float32Array(srcHeight);
+
+    // 連続する余白（低密度）領域の中心を検出
+    const whitespaceCenters = [];
+    let wsStart = -1;
+    for (let y = 0; y < srcHeight; y++) {
+      if (normalized[y] < whitespaceThreshold) {
+        if (wsStart < 0) wsStart = y;
+      } else {
+        if (wsStart >= 0) {
+          const center = Math.round((wsStart + y - 1) / 2);
+          // 余白が十分に広い場合のみ採用（画像高さの1%以上）
+          if (y - wsStart >= Math.max(3, Math.round(srcHeight * 0.01))) {
+            whitespaceCenters.push(center);
+          }
+          wsStart = -1;
+        }
+      }
+    }
+    if (wsStart >= 0) {
+      const center = Math.round((wsStart + srcHeight - 1) / 2);
+      if (srcHeight - wsStart >= Math.max(3, Math.round(srcHeight * 0.01))) {
+        whitespaceCenters.push(center);
+      }
+    }
+
+    // 罫線と余白を統合して最終的な分割Y座標配列を生成
+    const allSplitYs = new Set();
+
+    // 罫線のY座標をそのまま追加
+    for (const y of lineClusters) {
+      if (y > 0 && y < srcHeight - 1) {
+        allSplitYs.add(y);
+      }
+    }
+
+    // 余白の中心を追加（罫線に近い場合は罫線を優先）
+    const MERGE_DISTANCE = Math.max(8, Math.round(srcHeight * 0.012));
+    for (const wsY of whitespaceCenters) {
+      let nearLine = false;
+      for (const lineY of lineClusters) {
+        if (Math.abs(wsY - lineY) <= MERGE_DISTANCE) {
+          nearLine = true;
+          break;
+        }
+      }
+      if (!nearLine && wsY > 0 && wsY < srcHeight - 1) {
+        allSplitYs.add(wsY);
+      }
+    }
+
+    // 最終的な分割Y座標をソート
+    const splitYs = [...allSplitYs].sort((a, b) => a - b);
+
+    return { splitYs };
+
+  } finally {
+    projection?.delete();
+    linesMat?.delete();
+    edgeMat?.delete();
+    blurMat?.delete();
+    grayMat?.delete();
+    srcMat.delete();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // メッセージハンドラ
 // ---------------------------------------------------------------------------
 
@@ -367,6 +558,13 @@ self.onmessage = async (e) => {
         await initOpenCV();
         const perspectiveParams = detectDocumentCorners(e.data.imageData);
         self.postMessage({ type: "result", id, perspectiveParams });
+        break;
+      }
+      case "detectParagraphs": {
+        await initOpenCV();
+        const options = e.data.options || {};
+        const result = detectParagraphBoundaries(e.data.imageData, options);
+        self.postMessage({ type: "result", id, paragraphBoundaries: result });
         break;
       }
       default:

--- a/public/opencv-worker.js
+++ b/public/opencv-worker.js
@@ -416,17 +416,18 @@ function detectParagraphBoundaries(imageData, options = {}) {
     //    ウィンドウサイズを画像高さの5%にして罫線間の隙間を完全に消す
     const WINDOW_SIZE = Math.max(15, Math.round(srcHeight * 0.05));
     const smoothed = new Float32Array(srcHeight);
+    
+    // 累積和を使って O(height) で計算
+    const halfW = Math.floor(WINDOW_SIZE / 2);
+    const prefixSums = new Float64Array(srcHeight + 1);
     for (let y = 0; y < srcHeight; y++) {
-      let sum = 0;
-      let count = 0;
-      const halfW = Math.floor(WINDOW_SIZE / 2);
-      for (let dy = -halfW; dy <= halfW; dy++) {
-        const yy = y + dy;
-        if (yy >= 0 && yy < srcHeight) {
-          sum += projData[yy];
-          count++;
-        }
-      }
+      prefixSums[y + 1] = prefixSums[y] + projData[y];
+    }
+    for (let y = 0; y < srcHeight; y++) {
+      const start = Math.max(0, y - halfW);
+      const end = Math.min(srcHeight - 1, y + halfW);
+      const sum = prefixSums[end + 1] - prefixSums[start];
+      const count = end - start + 1;
       smoothed[y] = sum / count;
     }
 

--- a/public/opencv-worker.js
+++ b/public/opencv-worker.js
@@ -476,8 +476,9 @@ function detectParagraphBoundaries(imageData, options = {}) {
       }
     }
 
-    // 9. 余白のY座標を境界として採用
+    // 9. 余白のY座標を境界として採用（先頭/末尾に接する余白は除外）
     const splitYs = whitespaceRegions
+      .filter(function(r) { return r.start > 0 && r.end < srcHeight - 1; })
       .map(function(r) { return r.center; })
       .filter(function(y) { return y > 0 && y < srcHeight - 1; })
       .sort(function(a, b) { return a - b; });

--- a/public/opencv-worker.js
+++ b/public/opencv-worker.js
@@ -349,26 +349,30 @@ function detectDocumentCorners(imageData) {
 // ---------------------------------------------------------------------------
 
 /**
- * OpenCV.js を使用して水平罫線と余白から段落境界を検出する。
+ * OpenCV.js を使用してテキスト領域間の余白から段落境界を検出する。
+ *
+ * 手帳の罫線は段落区切りとして誤検出されるため、HoughLinesP は使用しない。
+ * 代わりに形態素演算（モルフォロジー）でテキスト領域を結合し、
+ * 垂直投射密度の大きな谷（テキストが存在しない領域）を段落境界とする。
  *
  * アルゴリズム:
- * 1. グレースケール → ガウシアンブラー
- * 2. Canny エッジ検出
- * 3. HoughLinesP で線分を検出
- * 4. 水平に近い線分（角度±15°以内）を抽出
- * 5. Y座標が近い線分をクラスタリングして代表Y座標を算出
- * 6. 行ごとのピクセル投射密度を計算して、余白（テキスト密度の谷）を検出
- * 7. 罫線のY座標と余白のY座標を統合して段落境界のY座標配列を生成
+ * 1. グレースケール → 大きめのガウシアンブラー（罫線ノイズ除去）
+ * 2. 二値化（Otsu）
+ * 3. モルフォロジークロージング（水平方向に長いカーネルで文字を結合）
+ *    → テキスト行が横方向に繋がったブロックになる
+ * 4. 垂直投射（reduce SUM）で行ごとの白/黒面積比を計算
+ * 5. 大きな移動平均で平滑化（罫線間の微小隙間を消す）
+ * 6. 閾値以下の連続領域 → 余白候補
+ * 7. 余白の最小高さフィルタ（画像高さの3%以上のみ採用）
  *
  * @param {{ data: Uint8ClampedArray, width: number, height: number }} imageData
- * @param {{ minLineLength?: number, maxAngleDeg?: number, whitespaceThreshold?: number }} options
+ * @param {{ minGapRatio?: number, densityThreshold?: number }} options
  * @returns {{ splitYs: number[] }}
  */
 function detectParagraphBoundaries(imageData, options = {}) {
   const {
-    minLineLength = imageData.width * 0.15,
-    maxAngleDeg = 15,
-    whitespaceThreshold = 0.03,
+    minGapRatio = 0.03,
+    densityThreshold = 0.05,
   } = options;
 
   const { data, width: srcWidth, height: srcHeight } = imageData;
@@ -376,77 +380,41 @@ function detectParagraphBoundaries(imageData, options = {}) {
 
   let grayMat = null;
   let blurMat = null;
-  let edgeMat = null;
-  let linesMat = null;
+  let binMat = null;
+  let closeKernel = null;
+  let closeMat = null;
   let projection = null;
 
   try {
-    // グレースケール
+    // 1. グレースケール
     grayMat = new cv.Mat();
     cv.cvtColor(srcMat, grayMat, cv.COLOR_RGBA2GRAY);
 
-    // ガウシアンブラー
+    // 2. 大きめのガウシアンブラー（罫線の細い線をぼかして消す）
     blurMat = new cv.Mat();
-    const kSize = Math.min(5, Math.max(3, Math.round(Math.min(srcWidth, srcHeight) / 200)));
-    const k = kSize % 2 === 0 ? kSize + 1 : kSize;
-    cv.GaussianBlur(grayMat, blurMat, new cv.Size(k, k), 0);
+    const blurK = Math.min(15, Math.max(5, Math.round(Math.min(srcWidth, srcHeight) / 50)));
+    const blurKOdd = blurK % 2 === 0 ? blurK + 1 : blurK;
+    cv.GaussianBlur(grayMat, blurMat, new cv.Size(blurKOdd, blurKOdd), 0);
 
-    // Canny エッジ検出
-    edgeMat = new cv.Mat();
-    cv.Canny(blurMat, edgeMat, 50, 150);
+    // 3. 二値化（Otsu で自動閾値）
+    binMat = new cv.Mat();
+    cv.threshold(blurMat, binMat, 0, 255, cv.THRESH_BINARY_INV + cv.THRESH_OTSU);
 
-    // HoughLinesP で線分検出
-    linesMat = new cv.Mat();
-    const minLinePx = Math.max(20, Math.round(minLineLength));
-    cv.HoughLinesP(edgeMat, linesMat, 1, Math.PI / 180, 50, minLinePx, 10);
+    // 4. モルフォロジークロージング（水平方向に文字を結合してテキストブロックにする）
+    closeMat = new cv.Mat();
+    const closeW = Math.max(15, Math.round(srcWidth * 0.02));
+    const closeH = Math.max(3, Math.round(srcHeight * 0.005));
+    closeKernel = cv.getStructuringElement(cv.MORPH_RECT, new cv.Size(closeW, closeH));
+    cv.morphologyEx(binMat, closeMat, cv.MORPH_CLOSE, closeKernel);
 
-    // 水平に近い線分を抽出（角度±maxAngleDeg度以内）
-    const maxAngleRad = (maxAngleDeg * Math.PI) / 180;
-    const lineYs = [];
-    for (let i = 0; i < linesMat.rows; i++) {
-      const x1 = linesMat.data32S[i * 4];
-      const y1 = linesMat.data32S[i * 4 + 1];
-      const x2 = linesMat.data32S[i * 4 + 2];
-      const y2 = linesMat.data32S[i * 4 + 3];
-
-      const dx = x2 - x1;
-      const dy = y2 - y1;
-      const length = Math.hypot(dx, dy);
-      if (length < 1) continue;
-
-      const angle = Math.abs(Math.atan2(dy, dx));
-      // 水平: angle ≈ 0 または angle ≈ π
-      if (angle <= maxAngleRad || angle >= Math.PI - maxAngleRad) {
-        const avgY = Math.round((y1 + y2) / 2);
-        lineYs.push(avgY);
-      }
-    }
-
-    // Y座標のクラスタリング（近いY座標をまとめる）
-    const CLUSTER_DISTANCE = Math.max(5, Math.round(srcHeight * 0.008));
-    const sorted = [...lineYs].sort((a, b) => a - b);
-    const lineClusters = [];
-    let clusterCenter = sorted.length > 0 ? sorted[0] : 0;
-    let clusterCount = 0;
-    for (const y of sorted) {
-      if (Math.abs(y - clusterCenter) <= CLUSTER_DISTANCE) {
-        clusterCenter = Math.round((clusterCenter * clusterCount + y) / (clusterCount + 1));
-        clusterCount++;
-      } else {
-        if (clusterCount >= 1) lineClusters.push(clusterCenter);
-        clusterCenter = y;
-        clusterCount = 1;
-      }
-    }
-    if (clusterCount >= 1) lineClusters.push(clusterCenter);
-
-    // 行投影密度（水平方向のピクセル数を各行でカウント）
+    // 5. 垂直投射（各行の黒ピクセル数を合計）
     projection = new cv.Mat();
-    cv.reduce(edgeMat, projection, 1, cv.REDUCE_SUM, cv.CV_32S);
-
-    // 投影値から移動平均を計算してノイズを平滑化
-    const WINDOW_SIZE = Math.max(3, Math.round(srcHeight * 0.01));
+    cv.reduce(closeMat, projection, 1, cv.REDUCE_SUM, cv.CV_32S);
     const projData = projection.data32S;
+
+    // 6. 大きな移動平均で平滑化
+    //    ウィンドウサイズを画像高さの5%にして罫線間の隙間を完全に消す
+    const WINDOW_SIZE = Math.max(15, Math.round(srcHeight * 0.05));
     const smoothed = new Float32Array(srcHeight);
     for (let y = 0; y < srcHeight; y++) {
       let sum = 0;
@@ -462,73 +430,64 @@ function detectParagraphBoundaries(imageData, options = {}) {
       smoothed[y] = sum / count;
     }
 
-    // 最大投影値で正規化
+    // 7. 最大投射値で正規化
     let maxProj = 0;
     for (let y = 0; y < srcHeight; y++) {
       if (smoothed[y] > maxProj) maxProj = smoothed[y];
     }
     const normalized = maxProj > 0
-      ? smoothed.map((v) => v / maxProj)
+      ? smoothed.map(function(v) { return v / maxProj; })
       : new Float32Array(srcHeight);
 
-    // 連続する余白（低密度）領域の中心を検出
-    const whitespaceCenters = [];
-    let wsStart = -1;
+    // 8. 連続する余白（低密度）領域の中心を検出
+    //    最小ギャップ高さ = 画像高さの minGapRatio（デフォルト3%）以上
+    const minGapHeight = Math.max(5, Math.round(srcHeight * minGapRatio));
+    const whitespaceRegions = [];
+    var wsStart = -1;
     for (let y = 0; y < srcHeight; y++) {
-      if (normalized[y] < whitespaceThreshold) {
+      if (normalized[y] < densityThreshold) {
         if (wsStart < 0) wsStart = y;
       } else {
         if (wsStart >= 0) {
-          const center = Math.round((wsStart + y - 1) / 2);
-          // 余白が十分に広い場合のみ採用（画像高さの1%以上）
-          if (y - wsStart >= Math.max(3, Math.round(srcHeight * 0.01))) {
-            whitespaceCenters.push(center);
+          const gapHeight = y - wsStart;
+          if (gapHeight >= minGapHeight) {
+            whitespaceRegions.push({
+              start: wsStart,
+              end: y - 1,
+              center: Math.round((wsStart + y - 1) / 2),
+              height: gapHeight,
+            });
           }
           wsStart = -1;
         }
       }
     }
+    // 画像末尾の余白
     if (wsStart >= 0) {
-      const center = Math.round((wsStart + srcHeight - 1) / 2);
-      if (srcHeight - wsStart >= Math.max(3, Math.round(srcHeight * 0.01))) {
-        whitespaceCenters.push(center);
+      const gapHeight = srcHeight - wsStart;
+      if (gapHeight >= minGapHeight) {
+        whitespaceRegions.push({
+          start: wsStart,
+          end: srcHeight - 1,
+          center: Math.round((wsStart + srcHeight - 1) / 2),
+          height: gapHeight,
+        });
       }
     }
 
-    // 罫線と余白を統合して最終的な分割Y座標配列を生成
-    const allSplitYs = new Set();
+    // 9. 余白のY座標を境界として採用
+    const splitYs = whitespaceRegions
+      .map(function(r) { return r.center; })
+      .filter(function(y) { return y > 0 && y < srcHeight - 1; })
+      .sort(function(a, b) { return a - b; });
 
-    // 罫線のY座標をそのまま追加
-    for (const y of lineClusters) {
-      if (y > 0 && y < srcHeight - 1) {
-        allSplitYs.add(y);
-      }
-    }
-
-    // 余白の中心を追加（罫線に近い場合は罫線を優先）
-    const MERGE_DISTANCE = Math.max(8, Math.round(srcHeight * 0.012));
-    for (const wsY of whitespaceCenters) {
-      let nearLine = false;
-      for (const lineY of lineClusters) {
-        if (Math.abs(wsY - lineY) <= MERGE_DISTANCE) {
-          nearLine = true;
-          break;
-        }
-      }
-      if (!nearLine && wsY > 0 && wsY < srcHeight - 1) {
-        allSplitYs.add(wsY);
-      }
-    }
-
-    // 最終的な分割Y座標をソート
-    const splitYs = [...allSplitYs].sort((a, b) => a - b);
-
-    return { splitYs };
+    return { splitYs: splitYs };
 
   } finally {
     projection?.delete();
-    linesMat?.delete();
-    edgeMat?.delete();
+    closeMat?.delete();
+    closeKernel?.delete();
+    binMat?.delete();
     blurMat?.delete();
     grayMat?.delete();
     srcMat.delete();

--- a/src/components/ParagraphCard.tsx
+++ b/src/components/ParagraphCard.tsx
@@ -14,7 +14,7 @@ export type ParagraphCardProps = {
   imageUrl: string;
   /** 段落の表示順。 */
   index: number;
-  /** 段落の削除コールバック。 */
+  /** 隣接段落との結合コールバック（分割線を1本削除して前後段落とマージする）。 */
   onDelete: (id: string) => void;
   /** 段落の順序入れ替えコールバック。 */
   onMoveUp?: (id: string) => void;
@@ -181,8 +181,8 @@ export function ParagraphCard({
             type="button"
             onClick={() => onDelete(paragraph.id)}
             className="p-1 text-slate-400 hover:text-red-500"
-            aria-label="段落を削除"
-            title="段落を削除"
+            aria-label="隣接段落と結合"
+            title="隣接段落と結合（分割線を削除）"
           >
             ✕
           </button>

--- a/src/components/ParagraphCard.tsx
+++ b/src/components/ParagraphCard.tsx
@@ -57,8 +57,16 @@ function CropPreview({
         if (!canvas) return;
 
         const { x, y, width, height } = cropRect;
-        const srcW = Math.max(1, Math.min(width, img.naturalWidth - x));
-        const srcH = Math.max(1, Math.min(height, img.naturalHeight - y));
+        const availW = img.naturalWidth - x;
+        const availH = img.naturalHeight - y;
+
+        if (availW <= 0 || availH <= 0) {
+          setStatus("error");
+          return;
+        }
+
+        const srcW = Math.min(width, availW);
+        const srcH = Math.min(height, availH);
 
         if (srcW < 1 || srcH < 1) {
           setStatus("error");

--- a/src/components/ParagraphCard.tsx
+++ b/src/components/ParagraphCard.tsx
@@ -45,6 +45,7 @@ function CropPreview({
   useEffect(() => {
     let cancelled = false;
     const renderId = ++renderIdRef.current;
+    setStatus("loading");
 
     const img = new Image();
     img.crossOrigin = "anonymous";

--- a/src/components/ParagraphCard.tsx
+++ b/src/components/ParagraphCard.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import type { ParagraphObject, CropRect } from "@/types/scan";
+
+// ---------------------------------------------------------------------------
+// 型定義
+// ---------------------------------------------------------------------------
+
+export type ParagraphCardProps = {
+  /** 段落オブジェクト。 */
+  paragraph: ParagraphObject;
+  /** 切り抜き元の画像 URL。 */
+  imageUrl: string;
+  /** 段落の表示順。 */
+  index: number;
+  /** 段落の削除コールバック。 */
+  onDelete: (id: string) => void;
+  /** 段落の順序入れ替えコールバック。 */
+  onMoveUp?: (id: string) => void;
+  /** 段落の順序入れ替えコールバック。 */
+  onMoveDown?: (id: string) => void;
+  /** 最大表示幅（px）。 */
+  maxWidth?: number;
+};
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+/** Canvas で指定領域を切り抜きプレビューする。 */
+function CropPreview({
+  imageUrl,
+  cropRect,
+  maxWidth = 400,
+}: {
+  imageUrl: string;
+  cropRect: CropRect;
+  maxWidth?: number;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const renderIdRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const renderId = ++renderIdRef.current;
+
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+
+    img.addEventListener("load", () => {
+      if (cancelled || renderId !== renderIdRef.current) return;
+      try {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+
+        const { x, y, width, height } = cropRect;
+        const srcW = Math.max(1, Math.min(width, img.naturalWidth - x));
+        const srcH = Math.max(1, Math.min(height, img.naturalHeight - y));
+
+        if (srcW < 1 || srcH < 1) {
+          setStatus("error");
+          return;
+        }
+
+        let drawW = srcW;
+        let drawH = srcH;
+        if (maxWidth && drawW > maxWidth) {
+          const scale = maxWidth / drawW;
+          drawW = maxWidth;
+          drawH = Math.round(drawH * scale);
+        }
+
+        canvas.width = drawW;
+        canvas.height = drawH;
+        const ctx = canvas.getContext("2d")!;
+        ctx.drawImage(img, x, y, srcW, srcH, 0, 0, drawW, drawH);
+
+        setStatus("ready");
+      } catch {
+        if (!cancelled) setStatus("error");
+      }
+    });
+
+    img.addEventListener("error", () => {
+      if (!cancelled && renderId === renderIdRef.current) {
+        setStatus("error");
+      }
+    });
+
+    img.src = imageUrl;
+
+    return () => {
+      cancelled = true;
+      renderIdRef.current = -1;
+    };
+  }, [imageUrl, cropRect, maxWidth]);
+
+  return (
+    <div className="relative bg-slate-50 rounded border border-slate-200 overflow-hidden">
+      {status === "loading" && (
+        <div className="flex items-center justify-center py-8">
+          <div className="text-slate-400 text-xs">読み込み中...</div>
+        </div>
+      )}
+      {status === "error" && (
+        <div className="flex items-center justify-center py-8">
+          <div className="text-red-400 text-xs">表示できません</div>
+        </div>
+      )}
+      <canvas
+        ref={canvasRef}
+        className={`max-w-full h-auto ${status !== "ready" ? "hidden" : ""}`}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// メインコンポーネント
+// ---------------------------------------------------------------------------
+
+/**
+ * 段落カードコンポーネント。
+ *
+ * 段落ごとの切り抜きプレビュー（Canvas crop）を表示し、
+ * 上下の移動・削除操作を提供する。
+ */
+export function ParagraphCard({
+  paragraph,
+  imageUrl,
+  index,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+  maxWidth,
+}: ParagraphCardProps) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white overflow-hidden shadow-sm">
+      <div className="flex items-center justify-between px-3 py-2 bg-slate-50 border-b border-slate-200">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-700 text-xs font-semibold">
+            {index + 1}
+          </span>
+          <span className="text-xs text-slate-500">
+            Y:{paragraph.cropRect.y}〜{paragraph.cropRect.y + paragraph.cropRect.height}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => onMoveUp?.(paragraph.id)}
+            disabled={!onMoveUp}
+            className="p-1 text-slate-400 hover:text-slate-600 disabled:opacity-30 disabled:cursor-not-allowed"
+            aria-label="上に移動"
+            title="上に移動"
+          >
+            ▲
+          </button>
+          <button
+            type="button"
+            onClick={() => onMoveDown?.(paragraph.id)}
+            disabled={!onMoveDown}
+            className="p-1 text-slate-400 hover:text-slate-600 disabled:opacity-30 disabled:cursor-not-allowed"
+            aria-label="下に移動"
+            title="下に移動"
+          >
+            ▼
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(paragraph.id)}
+            className="p-1 text-slate-400 hover:text-red-500"
+            aria-label="段落を削除"
+            title="段落を削除"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+      <div className="p-2">
+        <CropPreview
+          imageUrl={imageUrl}
+          cropRect={paragraph.cropRect}
+          maxWidth={maxWidth}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -140,6 +140,8 @@ export function ParagraphSplitUI({
   );
   const [autoDetectLoading, setAutoDetectLoading] = useState(false);
   const [autoDetectMessage, setAutoDetectMessage] = useState<{ type: "success" | "warn"; text: string } | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
   const [correctedImageUrl, setCorrectedImageUrl] = useState<string | null>(null);
   const mountedRef = useRef(true);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -160,6 +162,7 @@ export function ParagraphSplitUI({
 
     async function loadAndCorrect() {
       setLoading(true);
+      setLoadError(null);
       try {
         const img = await loadImageElement(imageUrl);
         if (cancelled) return;
@@ -218,6 +221,7 @@ export function ParagraphSplitUI({
       } catch (err) {
         if (!cancelled) {
           console.error(err);
+          setLoadError(err instanceof Error ? err.message : "画像の読み込みまたは補正に失敗しました。");
           setLoading(false);
         }
       }
@@ -228,7 +232,7 @@ export function ParagraphSplitUI({
     return () => {
       cancelled = true;
     };
-  }, [imageUrl, correction, existingSplit]);
+  }, [imageUrl, correction, existingSplit, retryKey]);
 
   // correctedImageUrl の ObjectURL を cleanup で解放（unmount 時・URL 変更時の両方をカバー）
   useEffect(() => {
@@ -471,6 +475,30 @@ export function ParagraphSplitUI({
     return (
       <div className="flex items-center justify-center py-12">
         <div className="text-slate-400">画像を読み込み中...</div>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-12">
+        <p className="text-sm text-red-600">{loadError}</p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => { setLoadError(null); setRetryKey((k) => k + 1); }}
+            className="px-3 py-1.5 text-sm rounded bg-blue-600 text-white hover:bg-blue-700"
+          >
+            再試行
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1.5 text-sm rounded bg-slate-200 text-slate-700 hover:bg-slate-300"
+          >
+            キャンセル
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -336,8 +336,8 @@ export function ParagraphSplitUI({
     e.preventDefault();
     e.stopPropagation();
     setDraggingIndex(index);
-    containerRef.current?.setPointerCapture(e.pointerId);
-  }, [containerRef]);
+    (e.currentTarget as Element).setPointerCapture(e.pointerId);
+  }, []);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
     if (draggingIndex === null || !containerRef.current || !imageSize) return;

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -393,11 +393,17 @@ export function ParagraphSplitUI({
   // ---- 段落操作 ----
 
   const handleDeleteParagraph = useCallback((id: string) => {
+    if (!imageSize) return;
     setParagraphs((prev) => {
-      const next = prev.filter((p) => p.id !== id);
-      const ys = paragraphsToSplitYs(next, imageSize?.height ?? 0);
-      setSplitYs(ys);
-      return next;
+      const idx = prev.findIndex((p) => p.id === id);
+      if (idx < 0 || prev.length <= 1) return prev;
+
+      const currentSplitYs = paragraphsToSplitYs(prev, imageSize.height);
+      // 先頭以外は上側の分割線を削除して前段落とマージ、先頭は下側の分割線を削除
+      const splitIndexToRemove = idx > 0 ? idx - 1 : 0;
+      const nextSplitYs = currentSplitYs.filter((_, i) => i !== splitIndexToRemove);
+      setSplitYs(nextSplitYs);
+      return splitYsToParagraphs(nextSplitYs, imageSize.width, imageSize.height);
     });
   }, [imageSize]);
 

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -1,0 +1,608 @@
+"use client";
+
+import {
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  useMemo,
+} from "react";
+import {
+  applyCorrections,
+  isOpencvLoaded,
+  initOpenCV,
+} from "@/lib/image-processing";
+import {
+  detectParagraphs,
+  splitYsToParagraphs,
+  createSplitResult,
+} from "@/lib/paragraph-detection";
+import { ParagraphCard } from "@/components/ParagraphCard";
+import type { CorrectionResult, ParagraphObject, SplitResult, CropRect } from "@/types/scan";
+
+// ---------------------------------------------------------------------------
+// 型定義
+// ---------------------------------------------------------------------------
+
+export type ParagraphSplitUIProps = {
+  /** 画像の URL（Blob URL / data URL / 通常 URL）。 */
+  imageUrl: string;
+  /** 適用する補正結果。undefined の場合は元画像をそのまま使用。 */
+  correction?: CorrectionResult;
+  /** 既存の分割結果（再編集時）。 */
+  existingSplit?: SplitResult;
+  /** 分割結果を保存したときのコールバック。 */
+  onSave: (split: SplitResult) => void;
+  /** キャンセル時のコールバック。 */
+  onCancel: () => void;
+};
+
+// ---------------------------------------------------------------------------
+// ヘルパー関数
+// ---------------------------------------------------------------------------
+
+/** 画像の自然サイズを読み込む。 */
+function loadImageNaturalSize(url: string): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.addEventListener("load", () => {
+      resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    });
+    img.addEventListener("error", () => {
+      reject(new Error("画像の読み込みに失敗しました。"));
+    });
+    img.src = url;
+  });
+}
+
+/** 指定したURLからImage要素を生成する。 */
+function loadImageElement(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.addEventListener("load", () => resolve(img));
+    img.addEventListener("error", () => reject(new Error("画像の読み込みに失敗しました。")));
+    img.src = url;
+  });
+}
+
+/** CropRect から Y 座標配列を抽出する（各段落の終端Yを分割線とする）。 */
+function paragraphsToSplitYs(paragraphs: ParagraphObject[], imageHeight: number): number[] {
+  return paragraphs
+    .filter((p) => p.cropRect.y > 0 && p.cropRect.y < imageHeight)
+    .map((p) => p.cropRect.y)
+    .sort((a, b) => a - b);
+}
+
+/** 一意のIDを生成する。 */
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+// ---------------------------------------------------------------------------
+// 分割線ハンドルコンポーネント
+// ---------------------------------------------------------------------------
+
+type SplitLineHandleProps = {
+  yPct: number;
+  /** 表示サイズ（px）。 */
+  size: number;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onDelete: () => void;
+  onDragStart?: () => void;
+};
+
+function SplitLineHandle({
+  yPct,
+  size,
+  onPointerDown,
+  onDelete,
+}: SplitLineHandleProps) {
+  return (
+    <div
+      className="absolute left-0 right-0 z-20 -translate-y-1/2 group"
+      style={{ top: `${yPct * 100}%` }}
+    >
+      <div
+        className="absolute inset-x-0 top-1/2 h-[2px] bg-red-500/70 pointer-events-none"
+      />
+      <div
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 cursor-grab active:cursor-grabbing touch-none"
+        style={{ width: size, height: size }}
+        onPointerDown={onPointerDown}
+        role="slider"
+        aria-label="分割線をドラッグ"
+        aria-valuenow={Math.round(yPct * 100)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        tabIndex={0}
+      >
+        <div className="w-full h-full rounded-full bg-red-500 border-2 border-white shadow-lg hover:bg-red-600 transition-colors" />
+      </div>
+      <button
+        type="button"
+        onClick={onDelete}
+        className="absolute right-1 top-1/2 -translate-y-1/2 w-5 h-5 rounded-full bg-white border border-red-300 text-red-500 text-[10px] flex items-center justify-center opacity-0 group-hover:opacity-100 hover:bg-red-50 transition-opacity"
+        aria-label="分割線を削除"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// メインコンポーネント
+// ---------------------------------------------------------------------------
+
+/**
+ * 段落分割 UI コンポーネント。
+ *
+ * - 補正済み（または元）画像に分割線をオーバーレイ表示
+ * - 分割線のドラッグ移動・追加・削除
+ * - 各段落の切り抜きプレビュー
+ * - 「自動検出」「手動分割のみ」の選択
+ * - 「保存」→ SplitResult をコールバックに渡す
+ */
+export function ParagraphSplitUI({
+  imageUrl,
+  correction,
+  existingSplit,
+  onSave,
+  onCancel,
+}: ParagraphSplitUIProps) {
+  // ---- 状態管理 ----
+
+  const [imageSize, setImageSize] = useState<{ width: number; height: number } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [opencvStatus, setOpencvStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
+  const [splitYs, setSplitYs] = useState<number[]>(() =>
+    existingSplit ? paragraphsToSplitYs(existingSplit.paragraphs, 0) : [],
+  );
+  const [paragraphs, setParagraphs] = useState<ParagraphObject[]>(() =>
+    existingSplit?.paragraphs ?? [],
+  );
+  const [autoDetectLoading, setAutoDetectLoading] = useState(false);
+  const [autoDetectMessage, setAutoDetectMessage] = useState<{ type: "success" | "warn"; text: string } | null>(null);
+  const [correctedCanvasUrl, setCorrectedCanvasUrl] = useState<string | null>(null);
+  const [correctedImageUrl, setCorrectedImageUrl] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const imageRef = useRef<HTMLImageElement>(null);
+
+  // ドラッグ状態
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+
+  // ---- 画像のロードと補正 ----
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadAndCorrect() {
+      setLoading(true);
+      try {
+        const img = await loadImageElement(imageUrl);
+        if (cancelled) return;
+
+        setImageSize({ width: img.naturalWidth, height: img.naturalHeight });
+
+        // 補正適用
+        let resultCanvas: HTMLCanvasElement;
+        if (correction) {
+          resultCanvas = await applyCorrections(img, correction);
+        } else {
+          resultCanvas = document.createElement("canvas");
+          resultCanvas.width = img.naturalWidth;
+          resultCanvas.height = img.naturalHeight;
+          const ctx = resultCanvas.getContext("2d")!;
+          ctx.drawImage(img, 0, 0);
+        }
+
+        if (cancelled) return;
+
+        // 補正済み画像のURLを生成
+        const blob = await new Promise<Blob>((resolve) => {
+          resultCanvas.toBlob((b) => resolve(b!), "image/png");
+        });
+        const url = URL.createObjectURL(blob);
+        setCorrectedCanvasUrl(url);
+        setCorrectedImageUrl(url);
+
+        // 既存の分割結果がない場合、Y座標配列を初期化
+        if (!existingSplit?.paragraphs?.length) {
+          setSplitYs([]);
+          setParagraphs([]);
+        } else {
+          // 補正後の画像サイズで段落を再構築
+          const ys = paragraphsToSplitYs(existingSplit.paragraphs, resultCanvas.height);
+          setSplitYs(ys);
+          setParagraphs(splitYsToParagraphs(ys, resultCanvas.width, resultCanvas.height));
+        }
+
+        setLoading(false);
+      } catch (err) {
+        if (!cancelled) {
+          console.error(err);
+          setLoading(false);
+        }
+      }
+    }
+
+    loadAndCorrect();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [imageUrl]);
+
+  // correctedCanvasUrl のクリーンアップ
+  useEffect(() => {
+    return () => {
+      if (correctedCanvasUrl) URL.revokeObjectURL(correctedCanvasUrl);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---- OpenCV.js の事前ロード ----
+
+  useEffect(() => {
+    if (isOpencvLoaded()) {
+      setOpencvStatus("ready");
+      return;
+    }
+    setOpencvStatus("loading");
+    initOpenCV()
+      .then(() => { if (mountedRef.current) setOpencvStatus("ready"); })
+      .catch(() => { if (mountedRef.current) setOpencvStatus("error"); });
+  }, []);
+
+  // ---- 段落の再計算 ----
+
+  const recalculateParagraphs = useCallback((ys: number[]) => {
+    if (!imageSize) return;
+    const sorted = [...ys].sort((a, b) => a - b);
+    setSplitYs(sorted);
+    setParagraphs(splitYsToParagraphs(sorted, imageSize.width, imageSize.height));
+  }, [imageSize]);
+
+  // ---- 自動検出 ----
+
+  const handleAutoDetect = useCallback(async () => {
+    if (!correctedImageUrl || !imageSize) return;
+
+    setAutoDetectLoading(true);
+    setAutoDetectMessage(null);
+
+    try {
+      const img = await loadImageElement(correctedImageUrl);
+      const detectedYs = await detectParagraphs(img);
+
+      if (!mountedRef.current) return;
+
+      if (detectedYs.length === 0) {
+        setAutoDetectMessage({ type: "warn", text: "段落境界が検出されませんでした。手動で分割線を追加してください。" });
+      } else {
+        setAutoDetectMessage({ type: "success", text: `${detectedYs.length}箇所の段落境界を検出しました。` });
+      }
+
+      recalculateParagraphs(detectedYs);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setAutoDetectMessage({
+        type: "warn",
+        text: err instanceof Error ? err.message : "自動検出に失敗しました。",
+      });
+    } finally {
+      if (mountedRef.current) setAutoDetectLoading(false);
+    }
+  }, [correctedImageUrl, imageSize, recalculateParagraphs]);
+
+  // ---- 手動分割線の追加 ----
+
+  const handleAddSplitLine = useCallback((yPct: number) => {
+    if (!imageSize) return;
+    const y = Math.round(yPct * imageSize.height);
+    if (y <= 0 || y >= imageSize.height - 1) return;
+
+    setSplitYs((prev) => {
+      if (prev.some((existingY) => Math.abs(existingY - y) < 3)) return prev;
+      const newSorted = [...prev, y].sort((a, b) => a - b);
+      setParagraphs(splitYsToParagraphs(newSorted, imageSize.width, imageSize.height));
+      return newSorted;
+    });
+  }, [imageSize]);
+
+  // 画像クリックで分割線を追加
+  const handleImageClick = useCallback((e: React.MouseEvent<HTMLImageElement>) => {
+    if (draggingIndex !== null) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const yPct = (e.clientY - rect.top) / rect.height;
+    handleAddSplitLine(yPct);
+  }, [draggingIndex, handleAddSplitLine]);
+
+  // ---- 分割線の削除 ----
+
+  const handleDeleteSplitLine = useCallback((index: number) => {
+    setSplitYs((prev) => {
+      const next = prev.filter((_, i) => i !== index);
+      if (imageSize) {
+        setParagraphs(splitYsToParagraphs(next, imageSize.width, imageSize.height));
+      }
+      return next;
+    });
+  }, [imageSize]);
+
+  // ---- 分割線のドラッグ ----
+
+  const handlePointerDown = useCallback((index: number) => (e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDraggingIndex(index);
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    if (draggingIndex === null || !containerRef.current || !imageSize) return;
+
+    const container = containerRef.current;
+    const rect = container.getBoundingClientRect();
+    const yPct = (e.clientY - rect.top) / rect.height;
+    const newY = Math.round(yPct * imageSize.height);
+    const clampedY = Math.max(1, Math.min(imageSize.height - 2, newY));
+
+    setSplitYs((prev) => {
+      const next = [...prev];
+      next[draggingIndex] = clampedY;
+      const sorted = [...next].sort((a, b) => a - b);
+
+      // ドラッグ中の要素のインデックスを更新
+      const newIndex = sorted.indexOf(clampedY);
+      setDraggingIndex(newIndex);
+      setParagraphs(splitYsToParagraphs(sorted, imageSize.width, imageSize.height));
+      return sorted;
+    });
+  }, [draggingIndex, imageSize]);
+
+  const handlePointerUp = useCallback(() => {
+    setDraggingIndex(null);
+  }, []);
+
+  // ---- 段落操作 ----
+
+  const handleDeleteParagraph = useCallback((id: string) => {
+    setParagraphs((prev) => {
+      const next = prev.filter((p) => p.id !== id);
+      const ys = paragraphsToSplitYs(next, imageSize?.height ?? 0);
+      setSplitYs(ys);
+      return next;
+    });
+  }, [imageSize]);
+
+  const handleMoveUp = useCallback((id: string) => {
+    setParagraphs((prev) => {
+      const idx = prev.findIndex((p) => p.id === id);
+      if (idx <= 0) return prev;
+      const next = [...prev];
+      [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
+      // order を更新
+      next.forEach((p, i) => { p.order = i; });
+      const ys = paragraphsToSplitYs(next, imageSize?.height ?? 0);
+      setSplitYs(ys);
+      return next;
+    });
+  }, [imageSize]);
+
+  const handleMoveDown = useCallback((id: string) => {
+    setParagraphs((prev) => {
+      const idx = prev.findIndex((p) => p.id === id);
+      if (idx < 0 || idx >= prev.length - 1) return prev;
+      const next = [...prev];
+      [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]];
+      next.forEach((p, i) => { p.order = i; });
+      const ys = paragraphsToSplitYs(next, imageSize?.height ?? 0);
+      setSplitYs(ys);
+      return next;
+    });
+  }, [imageSize]);
+
+  // ---- 全消去 ----
+
+  const handleClearAll = useCallback(() => {
+    setSplitYs([]);
+    setParagraphs([]);
+    setAutoDetectMessage(null);
+  }, []);
+
+  // ---- 保存 ----
+
+  const handleSave = useCallback(() => {
+    const result = createSplitResult(paragraphs);
+    onSave(result);
+  }, [paragraphs, onSave]);
+
+  // ---- スキップ（分割なしで保存） ----
+
+  const handleSkip = useCallback(() => {
+    const result = createSplitResult([]);
+    onSave(result);
+  }, [onSave]);
+
+  // ---- 計算プロパティ ----
+
+  const canSave = imageSize !== null;
+
+  const displayImageSrc = correctedImageUrl ?? imageUrl;
+
+  // ---- レンダリング ----
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-slate-400">画像を読み込み中...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-800">📝 段落分割</h3>
+          <p className="text-xs text-slate-500">
+            画像をクリックして分割線を追加、または自動検出を使用してください。
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {autoDetectMessage && (
+            <span className={`text-xs ${autoDetectMessage.type === "success" ? "text-green-600" : "text-amber-600"}`}>
+              {autoDetectMessage.text}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleAutoDetect}
+            disabled={autoDetectLoading || opencvStatus !== "ready"}
+            className="text-xs bg-blue-50 text-blue-600 hover:bg-blue-100 disabled:opacity-50 px-2 py-1 rounded border border-blue-200 hover:border-blue-300"
+          >
+            {autoDetectLoading ? "検出中..." : "🔍 自動検出"}
+          </button>
+          <button
+            type="button"
+            onClick={handleClearAll}
+            className="text-xs text-slate-500 hover:text-slate-700 px-2 py-1 rounded border border-slate-200 hover:border-slate-300"
+          >
+            全消去
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="text-xs text-slate-500 hover:text-slate-700 px-2 py-1"
+          >
+            キャンセル
+          </button>
+        </div>
+      </div>
+
+      {/* 画像表示エリア（分割線オーバーレイ） */}
+      <div
+        ref={containerRef}
+        className="relative select-none cursor-crosshair"
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          ref={imageRef}
+          src={displayImageSrc}
+          alt="分割対象画像"
+          className="w-full h-auto rounded-lg border border-slate-200"
+          draggable={false}
+          onClick={handleImageClick}
+        />
+
+        {/* 分割線オーバーレイ */}
+        {imageSize && (
+          <div className="absolute inset-0 pointer-events-none">
+            <svg
+              className="absolute inset-0 w-full h-full"
+              viewBox={`0 0 ${imageSize.width} ${imageSize.height}`}
+              preserveAspectRatio="none"
+            >
+              {splitYs.map((y, i) => (
+                <line
+                  key={`line-${i}`}
+                  x1={0}
+                  y1={y}
+                  x2={imageSize.width}
+                  y2={y}
+                  stroke="rgba(239, 68, 68, 0.6)"
+                  strokeWidth={Math.max(2, Math.round(imageSize.width / 400))}
+                  strokeDasharray="8,4"
+                />
+              ))}
+            </svg>
+          </div>
+        )}
+
+        {/* 分割線ハンドル */}
+        {imageSize &&
+          splitYs.map((y, i) => (
+            <div key={`handle-${i}`} className="absolute inset-x-0 pointer-events-auto" style={{ top: 0, bottom: 0 }}>
+              <SplitLineHandle
+                yPct={y / imageSize.height}
+                size={20}
+                onPointerDown={handlePointerDown(i)}
+                onDelete={() => handleDeleteSplitLine(i)}
+              />
+            </div>
+          ))}
+      </div>
+
+      {/* 段落プレビュー */}
+      <div>
+        <div className="text-xs font-medium text-slate-500 mb-2">
+          段落プレビュー ({paragraphs.length}段落)
+        </div>
+        {paragraphs.length === 0 ? (
+          <div className="text-center py-8 text-sm text-slate-400">
+            分割線がありません。画像をクリックするか「自動検出」を使用してください。
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {paragraphs.map((p, i) => (
+              <ParagraphCard
+                key={p.id}
+                paragraph={p}
+                imageUrl={displayImageSrc}
+                index={i}
+                onDelete={handleDeleteParagraph}
+                onMoveUp={i > 0 ? handleMoveUp : undefined}
+                onMoveDown={i < paragraphs.length - 1 ? handleMoveDown : undefined}
+                maxWidth={400}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* アクションボタン */}
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={handleSkip}
+          className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50 transition-colors"
+        >
+          ⏭️ 分割なしで保存
+        </button>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50 transition-colors"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            保存
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -395,12 +395,21 @@ export function ParagraphSplitUI({
   const handleDeleteParagraph = useCallback((id: string) => {
     if (!imageSize) return;
     setParagraphs((prev) => {
-      const idx = prev.findIndex((p) => p.id === id);
-      if (idx < 0 || prev.length <= 1) return prev;
+      const paragraph = prev.find((p) => p.id === id);
+      if (!paragraph || prev.length <= 1) return prev;
 
       const currentSplitYs = paragraphsToSplitYs(prev, imageSize.height);
-      // 先頭以外は上側の分割線を削除して前段落とマージ、先頭は下側の分割線を削除
-      const splitIndexToRemove = idx > 0 ? idx - 1 : 0;
+      // cropRect.y で split line を特定（idx ではなく Y 座標ベースで探索して
+      // handleMoveUp/handleMoveDown による並び替え後も正しい線を削除できるようにする）
+      let splitIndexToRemove: number;
+      if (paragraph.cropRect.y === 0) {
+        // 先頭段落：次段落との境界（最初の splitY）を削除して次段落とマージ
+        splitIndexToRemove = 0;
+      } else {
+        splitIndexToRemove = currentSplitYs.indexOf(paragraph.cropRect.y);
+        if (splitIndexToRemove === -1) return prev;
+      }
+
       const nextSplitYs = currentSplitYs.filter((_, i) => i !== splitIndexToRemove);
       setSplitYs(nextSplitYs);
       return splitYsToParagraphs(nextSplitYs, imageSize.width, imageSize.height);
@@ -408,17 +417,15 @@ export function ParagraphSplitUI({
   }, [imageSize]);
 
   const handleMoveUp = useCallback((id: string) => {
+    // display order は paragraphs 配列で管理し、splitYs（空間的な分割位置）は変更しない
     setParagraphs((prev) => {
       const idx = prev.findIndex((p) => p.id === id);
       if (idx <= 0) return prev;
       const next = [...prev];
       [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
-      const updated = next.map((p, i) => ({ ...p, order: i }));
-      const ys = paragraphsToSplitYs(updated, imageSize?.height ?? 0);
-      setSplitYs(ys);
-      return updated;
+      return next.map((p, i) => ({ ...p, order: i }));
     });
-  }, [imageSize]);
+  }, []);
 
   const handleMoveDown = useCallback((id: string) => {
     setParagraphs((prev) => {
@@ -426,12 +433,9 @@ export function ParagraphSplitUI({
       if (idx < 0 || idx >= prev.length - 1) return prev;
       const next = [...prev];
       [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]];
-      const updated = next.map((p, i) => ({ ...p, order: i }));
-      const ys = paragraphsToSplitYs(updated, imageSize?.height ?? 0);
-      setSplitYs(ys);
-      return updated;
+      return next.map((p, i) => ({ ...p, order: i }));
     });
-  }, [imageSize]);
+  }, []);
 
   // ---- 全消去 ----
 

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -5,7 +5,6 @@ import {
   useRef,
   useCallback,
   useEffect,
-  useMemo,
 } from "react";
 import {
   applyCorrections,
@@ -18,7 +17,7 @@ import {
   createSplitResult,
 } from "@/lib/paragraph-detection";
 import { ParagraphCard } from "@/components/ParagraphCard";
-import type { CorrectionResult, ParagraphObject, SplitResult, CropRect } from "@/types/scan";
+import type { CorrectionResult, ParagraphObject, SplitResult } from "@/types/scan";
 
 // ---------------------------------------------------------------------------
 // 型定義
@@ -41,21 +40,6 @@ export type ParagraphSplitUIProps = {
 // ヘルパー関数
 // ---------------------------------------------------------------------------
 
-/** 画像の自然サイズを読み込む。 */
-function loadImageNaturalSize(url: string): Promise<{ width: number; height: number }> {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.crossOrigin = "anonymous";
-    img.addEventListener("load", () => {
-      resolve({ width: img.naturalWidth, height: img.naturalHeight });
-    });
-    img.addEventListener("error", () => {
-      reject(new Error("画像の読み込みに失敗しました。"));
-    });
-    img.src = url;
-  });
-}
-
 /** 指定したURLからImage要素を生成する。 */
 function loadImageElement(url: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
@@ -73,11 +57,6 @@ function paragraphsToSplitYs(paragraphs: ParagraphObject[], imageHeight: number)
     .filter((p) => p.cropRect.y > 0 && p.cropRect.y < imageHeight)
     .map((p) => p.cropRect.y)
     .sort((a, b) => a - b);
-}
-
-/** 一意のIDを生成する。 */
-function generateId(): string {
-  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
 }
 
 // ---------------------------------------------------------------------------
@@ -107,19 +86,15 @@ function SplitLineHandle({
       <div
         className="absolute inset-x-0 top-1/2 h-[2px] bg-red-500/70"
       />
-      <div
+      <button
+        type="button"
         className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 cursor-grab active:cursor-grabbing touch-none pointer-events-auto"
         style={{ width: size, height: size }}
         onPointerDown={onPointerDown}
-        role="slider"
         aria-label="分割線をドラッグ"
-        aria-valuenow={Math.round(yPct * 100)}
-        aria-valuemin={0}
-        aria-valuemax={100}
-        tabIndex={0}
       >
         <div className="w-full h-full rounded-full bg-red-500 border-2 border-white shadow-lg hover:bg-red-600 transition-colors" />
-      </div>
+      </button>
       <button
         type="button"
         onClick={onDelete}
@@ -210,11 +185,22 @@ export function ParagraphSplitUI({
         setImageSize({ width: resultCanvas.width, height: resultCanvas.height });
 
         // 補正済み画像のURLを生成
-        const blob = await new Promise<Blob>((resolve) => {
-          resultCanvas.toBlob((b) => resolve(b!), "image/png");
+        const blob = await new Promise<Blob>((resolve, reject) => {
+          resultCanvas.toBlob((b) => {
+            if (b) {
+              resolve(b);
+            } else {
+              reject(new Error("補正済み画像の Blob 生成に失敗しました。"));
+            }
+          }, "image/png");
         });
         const url = URL.createObjectURL(blob);
-        setCorrectedCanvasUrl(url);
+        
+        // 新しい URL を設定する前に古い URL を解放
+        setCorrectedCanvasUrl((prev) => {
+          if (prev) URL.revokeObjectURL(prev);
+          return url;
+        });
         setCorrectedImageUrl(url);
 
         // 既存の分割結果がない場合、Y座標配列を初期化
@@ -244,14 +230,6 @@ export function ParagraphSplitUI({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [imageUrl]);
-
-  // correctedCanvasUrl のクリーンアップ
-  useEffect(() => {
-    return () => {
-      if (correctedCanvasUrl) URL.revokeObjectURL(correctedCanvasUrl);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // ---- OpenCV.js の事前ロード ----
 
@@ -362,11 +340,40 @@ export function ParagraphSplitUI({
 
     setSplitYs((prev) => {
       const next = [...prev];
-      next[draggingIndex] = clampedY;
+      
+      // 重複を回避するスナップ処理
+      const occupiedYs = new Set(prev.filter((_, index) => index !== draggingIndex));
+      
+      let resolvedY = clampedY;
+      if (occupiedYs.has(resolvedY)) {
+        let found = false;
+
+        for (let offset = 1; offset < imageSize.height; offset += 1) {
+          const up = clampedY - offset;
+          if (up >= 1 && up <= imageSize.height - 2 && !occupiedYs.has(up)) {
+            resolvedY = up;
+            found = true;
+            break;
+          }
+
+          const down = clampedY + offset;
+          if (down >= 1 && down <= imageSize.height - 2 && !occupiedYs.has(down)) {
+            resolvedY = down;
+            found = true;
+            break;
+          }
+        }
+
+        if (!found) {
+          return prev;
+        }
+      }
+
+      next[draggingIndex] = resolvedY;
       const sorted = [...next].sort((a, b) => a - b);
 
       // ドラッグ中の要素のインデックスを更新
-      const newIndex = sorted.indexOf(clampedY);
+      const newIndex = sorted.findIndex((y) => y === resolvedY);
       setDraggingIndex(newIndex);
       setParagraphs(splitYsToParagraphs(sorted, imageSize.width, imageSize.height));
       return sorted;

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -69,7 +69,6 @@ type SplitLineHandleProps = {
   size: number;
   onPointerDown: (e: React.PointerEvent) => void;
   onDelete: () => void;
-  onDragStart?: () => void;
 };
 
 function SplitLineHandle({
@@ -211,10 +210,11 @@ export function ParagraphSplitUI({
           setSplitYs([]);
           setParagraphs([]);
         } else {
-          // 補正後の画像サイズで段落を再構築
+          // splitYs はオーバーレイ表示用に再計算するが、paragraphs は
+          // existingSplit のものをそのまま使って id/order を保持する
           const ys = paragraphsToSplitYs(existingSplit.paragraphs, resultCanvas.height);
           setSplitYs(ys);
-          setParagraphs(splitYsToParagraphs(ys, resultCanvas.width, resultCanvas.height));
+          setParagraphs(existingSplit.paragraphs);
         }
 
         setLoading(false);

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -206,6 +206,9 @@ export function ParagraphSplitUI({
 
         if (cancelled) return;
 
+        // 補正後の画像サイズを imageSize に設定（台形補正等でサイズが変わるため）
+        setImageSize({ width: resultCanvas.width, height: resultCanvas.height });
+
         // 補正済み画像のURLを生成
         const blob = await new Promise<Blob>((resolve) => {
           resultCanvas.toBlob((b) => resolve(b!), "image/png");
@@ -345,8 +348,8 @@ export function ParagraphSplitUI({
     e.preventDefault();
     e.stopPropagation();
     setDraggingIndex(index);
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
+    containerRef.current?.setPointerCapture(e.pointerId);
+  }, [containerRef]);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
     if (draggingIndex === null || !containerRef.current || !imageSize) return;

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -97,7 +97,7 @@ function SplitLineHandle({
       <button
         type="button"
         onClick={onDelete}
-        className="absolute right-1 top-1/2 -translate-y-1/2 w-5 h-5 rounded-full bg-white border border-red-300 text-red-500 text-[10px] flex items-center justify-center opacity-0 group-hover:opacity-100 hover:bg-red-50 transition-opacity pointer-events-auto"
+        className="absolute right-1 top-1/2 -translate-y-1/2 w-5 h-5 rounded-full bg-white border border-red-300 text-red-500 text-[10px] flex items-center justify-center opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-red-50 transition-opacity pointer-events-auto"
         aria-label="分割線を削除"
       >
         ✕

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -146,7 +146,8 @@ export function ParagraphSplitUI({
   const containerRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
 
-  // ドラッグ状態
+  // ドラッグ状態（ref で即時更新し、state は再レンダー用）
+  const draggingIndexRef = useRef<number | null>(null);
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
 
   // ---- 画像のロードと補正 ----
@@ -335,12 +336,14 @@ export function ParagraphSplitUI({
   const handlePointerDown = useCallback((index: number) => (e: React.PointerEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    draggingIndexRef.current = index;
     setDraggingIndex(index);
     (e.currentTarget as Element).setPointerCapture(e.pointerId);
   }, []);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
-    if (draggingIndex === null || !containerRef.current || !imageSize) return;
+    const currentIndex = draggingIndexRef.current;
+    if (currentIndex === null || !containerRef.current || !imageSize) return;
 
     const container = containerRef.current;
     const rect = container.getBoundingClientRect();
@@ -350,10 +353,10 @@ export function ParagraphSplitUI({
 
     setSplitYs((prev) => {
       const next = [...prev];
-      
+
       // 重複を回避するスナップ処理
-      const occupiedYs = new Set(prev.filter((_, index) => index !== draggingIndex));
-      
+      const occupiedYs = new Set(prev.filter((_, i) => i !== currentIndex));
+
       let resolvedY = clampedY;
       if (occupiedYs.has(resolvedY)) {
         let found = false;
@@ -379,18 +382,20 @@ export function ParagraphSplitUI({
         }
       }
 
-      next[draggingIndex] = resolvedY;
+      next[currentIndex] = resolvedY;
       const sorted = [...next].sort((a, b) => a - b);
 
-      // ドラッグ中の要素のインデックスを更新
+      // ドラッグ中の要素のインデックスを ref と state の両方で即時更新
       const newIndex = sorted.findIndex((y) => y === resolvedY);
+      draggingIndexRef.current = newIndex;
       setDraggingIndex(newIndex);
       setParagraphs(splitYsToParagraphs(sorted, imageSize.width, imageSize.height));
       return sorted;
     });
-  }, [draggingIndex, imageSize]);
+  }, [imageSize]);
 
   const handlePointerUp = useCallback(() => {
+    draggingIndexRef.current = null;
     setDraggingIndex(null);
   }, []);
 

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -140,7 +140,6 @@ export function ParagraphSplitUI({
   );
   const [autoDetectLoading, setAutoDetectLoading] = useState(false);
   const [autoDetectMessage, setAutoDetectMessage] = useState<{ type: "success" | "warn"; text: string } | null>(null);
-  const [, setCorrectedCanvasUrl] = useState<string | null>(null);
   const [correctedImageUrl, setCorrectedImageUrl] = useState<string | null>(null);
   const mountedRef = useRef(true);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -195,18 +194,13 @@ export function ParagraphSplitUI({
           }, "image/png");
         });
         const url = URL.createObjectURL(blob);
-        
+
         // ObjectURL 生成後にキャンセルチェック
         if (cancelled) {
           URL.revokeObjectURL(url);
           return;
         }
-        
-        // 新しい URL を設定する前に古い URL を解放
-        setCorrectedCanvasUrl((prev) => {
-          if (prev) URL.revokeObjectURL(prev);
-          return url;
-        });
+
         setCorrectedImageUrl(url);
 
         // 既存の分割結果がない場合、Y座標配列を初期化
@@ -235,6 +229,13 @@ export function ParagraphSplitUI({
       cancelled = true;
     };
   }, [imageUrl, correction, existingSplit]);
+
+  // correctedImageUrl の ObjectURL を cleanup で解放（unmount 時・URL 変更時の両方をカバー）
+  useEffect(() => {
+    return () => {
+      if (correctedImageUrl) URL.revokeObjectURL(correctedImageUrl);
+    };
+  }, [correctedImageUrl]);
 
   // ---- OpenCV.js の事前ロード ----
 
@@ -406,11 +407,10 @@ export function ParagraphSplitUI({
       if (idx <= 0) return prev;
       const next = [...prev];
       [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
-      // order を更新
-      next.forEach((p, i) => { p.order = i; });
-      const ys = paragraphsToSplitYs(next, imageSize?.height ?? 0);
+      const updated = next.map((p, i) => ({ ...p, order: i }));
+      const ys = paragraphsToSplitYs(updated, imageSize?.height ?? 0);
       setSplitYs(ys);
-      return next;
+      return updated;
     });
   }, [imageSize]);
 
@@ -420,10 +420,10 @@ export function ParagraphSplitUI({
       if (idx < 0 || idx >= prev.length - 1) return prev;
       const next = [...prev];
       [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]];
-      next.forEach((p, i) => { p.order = i; });
-      const ys = paragraphsToSplitYs(next, imageSize?.height ?? 0);
+      const updated = next.map((p, i) => ({ ...p, order: i }));
+      const ys = paragraphsToSplitYs(updated, imageSize?.height ?? 0);
       setSplitYs(ys);
-      return next;
+      return updated;
     });
   }, [imageSize]);
 

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -140,7 +140,7 @@ export function ParagraphSplitUI({
   );
   const [autoDetectLoading, setAutoDetectLoading] = useState(false);
   const [autoDetectMessage, setAutoDetectMessage] = useState<{ type: "success" | "warn"; text: string } | null>(null);
-  const [correctedCanvasUrl, setCorrectedCanvasUrl] = useState<string | null>(null);
+  const [, setCorrectedCanvasUrl] = useState<string | null>(null);
   const [correctedImageUrl, setCorrectedImageUrl] = useState<string | null>(null);
   const mountedRef = useRef(true);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -196,6 +196,12 @@ export function ParagraphSplitUI({
         });
         const url = URL.createObjectURL(blob);
         
+        // ObjectURL 生成後にキャンセルチェック
+        if (cancelled) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+        
         // 新しい URL を設定する前に古い URL を解放
         setCorrectedCanvasUrl((prev) => {
           if (prev) URL.revokeObjectURL(prev);
@@ -228,8 +234,7 @@ export function ParagraphSplitUI({
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [imageUrl]);
+  }, [imageUrl, correction, existingSplit]);
 
   // ---- OpenCV.js の事前ロード ----
 

--- a/src/components/ParagraphSplitUI.tsx
+++ b/src/components/ParagraphSplitUI.tsx
@@ -101,14 +101,14 @@ function SplitLineHandle({
 }: SplitLineHandleProps) {
   return (
     <div
-      className="absolute left-0 right-0 z-20 -translate-y-1/2 group"
+      className="absolute left-0 right-0 z-20 -translate-y-1/2 group pointer-events-none"
       style={{ top: `${yPct * 100}%` }}
     >
       <div
-        className="absolute inset-x-0 top-1/2 h-[2px] bg-red-500/70 pointer-events-none"
+        className="absolute inset-x-0 top-1/2 h-[2px] bg-red-500/70"
       />
       <div
-        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 cursor-grab active:cursor-grabbing touch-none"
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 cursor-grab active:cursor-grabbing touch-none pointer-events-auto"
         style={{ width: size, height: size }}
         onPointerDown={onPointerDown}
         role="slider"
@@ -123,7 +123,7 @@ function SplitLineHandle({
       <button
         type="button"
         onClick={onDelete}
-        className="absolute right-1 top-1/2 -translate-y-1/2 w-5 h-5 rounded-full bg-white border border-red-300 text-red-500 text-[10px] flex items-center justify-center opacity-0 group-hover:opacity-100 hover:bg-red-50 transition-opacity"
+        className="absolute right-1 top-1/2 -translate-y-1/2 w-5 h-5 rounded-full bg-white border border-red-300 text-red-500 text-[10px] flex items-center justify-center opacity-0 group-hover:opacity-100 hover:bg-red-50 transition-opacity pointer-events-auto"
         aria-label="分割線を削除"
       >
         ✕
@@ -538,7 +538,7 @@ export function ParagraphSplitUI({
         {/* 分割線ハンドル */}
         {imageSize &&
           splitYs.map((y, i) => (
-            <div key={`handle-${i}`} className="absolute inset-x-0 pointer-events-auto" style={{ top: 0, bottom: 0 }}>
+            <div key={`handle-${i}`} className="absolute inset-x-0 pointer-events-none">
               <SplitLineHandle
                 yPct={y / imageSize.height}
                 size={20}

--- a/src/components/SessionDetailPanel.tsx
+++ b/src/components/SessionDetailPanel.tsx
@@ -7,8 +7,9 @@ import { createDriveClient } from "@/lib/drive-client";
 import { ImageCaptureModule } from "@/components/ImageCaptureModule";
 import { ScannerUploadModule } from "@/components/ScannerUploadModule";
 import { PerspectiveCorrectionUI } from "@/components/PerspectiveCorrectionUI";
+import { ParagraphSplitUI } from "@/components/ParagraphSplitUI";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
-import type { ScanSession, ScanPage, CorrectionResult } from "@/types/scan";
+import type { ScanSession, ScanPage, CorrectionResult, SplitResult } from "@/types/scan";
 
 // ---------------------------------------------------------------------------
 // 定数・ユーティリティ
@@ -51,12 +52,25 @@ function correctionBadge(session: ScanSession): string | null {
   return `${done}/${total}`;
 }
 
+function splitProgress(session: ScanSession): { done: number; total: number } {
+  const total = session.pages.filter((p) => p.correction !== undefined).length;
+  const done = session.pages.filter((p) => p.split !== undefined).length;
+  return { done, total };
+}
+
+function splitBadge(session: ScanSession): string | null {
+  const { done, total } = splitProgress(session);
+  if (total === 0) return null;
+  return `${done}/${total}`;
+}
+
 function StepNav({ currentStep, onStepChange, session }: StepNavProps) {
   return (
     <nav className="flex items-center gap-1 overflow-x-auto pb-1" aria-label="処理ステップ">
       {STEPS.map((step, idx) => {
         const isActive = currentStep === step.id;
-        const isClickable = step.id === "capture" || step.id === "correction";
+        const hasCorrectedPages = session.pages.some((p) => p.correction !== undefined);
+        const isClickable = step.id === "capture" || step.id === "correction" || (step.id === "split" && hasCorrectedPages);
         const badge =
           step.id === "capture"
             ? session.pages.length > 0
@@ -64,7 +78,9 @@ function StepNav({ currentStep, onStepChange, session }: StepNavProps) {
               : null
             : step.id === "correction"
               ? correctionBadge(session)
-              : null;
+              : step.id === "split"
+                ? splitBadge(session)
+                : null;
 
         return (
           <div key={step.id} className="flex items-center">
@@ -276,6 +292,93 @@ function CorrectionPageCard({ page, accessToken, onSelect }: CorrectionPageCardP
 }
 
 // ---------------------------------------------------------------------------
+// 分割ステップ：ページ一覧
+// ---------------------------------------------------------------------------
+
+type SplitPageCardProps = {
+  page: ScanPage;
+  accessToken: string;
+  onSelect: () => void;
+};
+
+function SplitPageCard({ page, accessToken, onSelect }: SplitPageCardProps) {
+  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    const client = createDriveClient(accessToken);
+
+    async function loadThumbnail() {
+      setLoading(true);
+      try {
+        const blob = await client.getFileBlob(page.originalFileId);
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setThumbnailUrl(objectUrl);
+      } catch {
+        if (!cancelled) setThumbnailUrl(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    loadThumbnail();
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [page.originalFileId, accessToken]);
+
+  const statusLabel = page.split === undefined
+    ? "未分割"
+    : page.split.paragraphs.length === 0
+      ? "分割なし"
+      : `${page.split.paragraphs.length}段落`;
+
+  const statusColor = page.split === undefined
+    ? "bg-amber-100 text-amber-700"
+    : "bg-green-100 text-green-700";
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="group relative rounded-lg border border-slate-200 bg-white overflow-hidden shadow-sm hover:border-blue-400 hover:shadow-md transition-all text-left"
+    >
+      <div className="aspect-[3/4] bg-slate-100">
+        {loading && (
+          <div className="flex items-center justify-center h-full">
+            <div className="text-slate-300 text-sm">読み込み中...</div>
+          </div>
+        )}
+        {thumbnailUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={thumbnailUrl}
+            alt={`ページ ${page.id}`}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        )}
+      </div>
+      <div className="p-2 flex items-center justify-between">
+        <p className="text-xs text-slate-500">{formatDateTime(page.capturedAt)}</p>
+        <span className={`text-[10px] font-medium rounded-full px-1.5 py-0.5 ${statusColor}`}>
+          {statusLabel}
+        </span>
+      </div>
+      <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/20 rounded-lg">
+        <span className="rounded-lg bg-white/90 px-3 py-1.5 text-sm font-medium text-slate-700 shadow">
+          分割する
+        </span>
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // メインコンポーネント
 // ---------------------------------------------------------------------------
 
@@ -303,6 +406,10 @@ export function SessionDetailPanel({ sessionId, onBack }: SessionDetailPanelProp
   // 補正用の画像 Blob URL
   const [correctionImageUrl, setCorrectionImageUrl] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  // 分割用の状態
+  const [splittingPageId, setSplittingPageId] = useState<string | null>(null);
+  const [splitImageUrl, setSplitImageUrl] = useState<string | null>(null);
 
   const loadSession = useCallback(async () => {
     if (!sessionManager || !sessionId) return;
@@ -416,6 +523,62 @@ export function SessionDetailPanel({ sessionId, onBack }: SessionDetailPanelProp
       if (correctionImageUrl) URL.revokeObjectURL(correctionImageUrl);
     };
   }, [correctionImageUrl]);
+
+  // ---- 分割ハンドラ ----
+
+  const handleSelectPageForSplit = useCallback(
+    async (page: ScanPage) => {
+      if (!accessToken) return;
+      setOperationError(null);
+      try {
+        const client = createDriveClient(accessToken);
+        const blob = await client.getFileBlob(page.originalFileId);
+        const url = URL.createObjectURL(blob);
+        setSplitImageUrl(url);
+        setSplittingPageId(page.id);
+      } catch (err) {
+        setOperationError(err instanceof Error ? err.message : "画像の読み込みに失敗しました。");
+      }
+    },
+    [accessToken],
+  );
+
+  const handleSaveSplit = useCallback(
+    async (split: SplitResult) => {
+      if (!sessionManager || !sessionId || !splittingPageId) return;
+      setSaving(true);
+      setOperationError(null);
+      try {
+        await sessionManager.updatePageSplit(sessionId, splittingPageId, split);
+        setSplittingPageId(null);
+        if (splitImageUrl) {
+          URL.revokeObjectURL(splitImageUrl);
+          setSplitImageUrl(null);
+        }
+        await loadSession();
+      } catch (err) {
+        setOperationError(err instanceof Error ? err.message : "分割結果の保存に失敗しました。");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [sessionManager, sessionId, splittingPageId, splitImageUrl, loadSession],
+  );
+
+  const handleCancelSplit = useCallback(() => {
+    setSplittingPageId(null);
+    if (splitImageUrl) {
+      URL.revokeObjectURL(splitImageUrl);
+      setSplitImageUrl(null);
+    }
+  }, [splitImageUrl]);
+
+  // 分割用 URL のクリーンアップ
+  useEffect(() => {
+    return () => {
+      if (splitImageUrl) URL.revokeObjectURL(splitImageUrl);
+    };
+  }, [splitImageUrl]);
 
   // ---- レンダリング ----
 
@@ -600,14 +763,67 @@ export function SessionDetailPanel({ sessionId, onBack }: SessionDetailPanelProp
         </div>
       )}
 
-      {/* Step 3: 段落分割（準備中） */}
+      {/* Step 3: 段落分割 */}
       {activeStep === "split" && (
-        <div className="text-center py-16">
-          <div className="text-5xl mb-4">📝</div>
-          <p className="text-lg text-slate-500 mb-2">段落分割（準備中）</p>
-          <p className="text-sm text-slate-400">
-            補正済みの画像から水平罫線・余白で文節境界を自動検出する機能です。
-          </p>
+        <div>
+          {splittingPageId && splitImageUrl ? (
+            <div>
+              <button
+                type="button"
+                onClick={handleCancelSplit}
+                disabled={saving}
+                className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 mb-4 disabled:opacity-50"
+              >
+                ← 分割ページ一覧に戻る
+              </button>
+
+              {operationError && (
+                <div className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+                  {operationError}
+                </div>
+              )}
+
+              <ParagraphSplitUI
+                imageUrl={splitImageUrl}
+                correction={session.pages.find((p) => p.id === splittingPageId)?.correction}
+                existingSplit={session.pages.find((p) => p.id === splittingPageId)?.split}
+                onSave={handleSaveSplit}
+                onCancel={handleCancelSplit}
+              />
+            </div>
+          ) : (
+            <>
+              <div className="mb-4">
+                <h2 className="text-lg font-semibold text-slate-800 mb-1">📝 段落分割</h2>
+                <p className="text-sm text-slate-500">
+                  補正済みのページをクリックして、水平罫線・余白で段落境界を自動検出または手動で分割します。
+                </p>
+              </div>
+
+              {session.pages.filter((p) => p.correction !== undefined).length === 0 ? (
+                <div className="text-center py-16">
+                  <div className="text-5xl mb-4">✂️</div>
+                  <p className="text-lg text-slate-500 mb-2">補正済みのページがありません</p>
+                  <p className="text-sm text-slate-400">
+                    まず「補正」ステップで画像を補正してください。
+                  </p>
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                  {session.pages
+                    .filter((p) => p.correction !== undefined)
+                    .map((page) => (
+                      <SplitPageCard
+                        key={page.id}
+                        page={page}
+                        accessToken={accessToken ?? ""}
+                        onSelect={() => handleSelectPageForSplit(page)}
+                      />
+                    ))}
+                </div>
+              )}
+            </>
+          )}
         </div>
       )}
 

--- a/src/components/SessionDetailPanel.tsx
+++ b/src/components/SessionDetailPanel.tsx
@@ -535,9 +535,9 @@ export function SessionDetailPanel({ sessionId, onBack }: SessionDetailPanelProp
       if (!accessToken) return;
       setOperationError(null);
       
-      // リクエスト ID を生成して並行実行時の競合を回避
-      const requestId = Date.now();
-      selectPageRequestIdRef.current = requestId;
+      // リクエスト ID を生成して並行実行時の競合を回避（単調増加で衝突なし）
+      selectPageRequestIdRef.current += 1;
+      const requestId = selectPageRequestIdRef.current;
       
       try {
         const client = createDriveClient(accessToken);

--- a/src/components/SessionDetailPanel.tsx
+++ b/src/components/SessionDetailPanel.tsx
@@ -531,18 +531,36 @@ export function SessionDetailPanel({ sessionId, onBack }: SessionDetailPanelProp
     async (page: ScanPage) => {
       if (!accessToken) return;
       setOperationError(null);
+      
+      // リクエスト ID を生成して並行実行時の競合を回避
+      const requestId = Date.now();
+      handleSelectPageForSplit.currentRequestId = requestId;
+      
       try {
         const client = createDriveClient(accessToken);
         const blob = await client.getFileBlob(page.originalFileId);
+        
+        // 最新のリクエストでない場合は破棄
+        if (handleSelectPageForSplit.currentRequestId !== requestId) {
+          URL.revokeObjectURL(URL.createObjectURL(blob));
+          return;
+        }
+        
         const url = URL.createObjectURL(blob);
         setSplitImageUrl(url);
         setSplittingPageId(page.id);
       } catch (err) {
-        setOperationError(err instanceof Error ? err.message : "画像の読み込みに失敗しました。");
+        // 最新のリクエストでのエラーのみを表示
+        if (handleSelectPageForSplit.currentRequestId === requestId) {
+          setOperationError(err instanceof Error ? err.message : "画像の読み込みに失敗しました。");
+        }
       }
     },
     [accessToken],
   );
+  
+  // リクエスト ID を格納するプロパティを追加
+  handleSelectPageForSplit.currentRequestId = 0;
 
   const handleSaveSplit = useCallback(
     async (split: SplitResult) => {

--- a/src/components/SessionDetailPanel.tsx
+++ b/src/components/SessionDetailPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useAuth } from "@/lib/auth-context";
 import { useInitializeApp } from "@/lib/use-initialize-app";
 import { createDriveClient } from "@/lib/drive-client";
@@ -54,7 +54,7 @@ function correctionBadge(session: ScanSession): string | null {
 
 function splitProgress(session: ScanSession): { done: number; total: number } {
   const total = session.pages.filter((p) => p.correction !== undefined).length;
-  const done = session.pages.filter((p) => p.split !== undefined).length;
+  const done = session.pages.filter((p) => p.correction !== undefined && p.split !== undefined).length;
   return { done, total };
 }
 

--- a/src/components/SessionDetailPanel.tsx
+++ b/src/components/SessionDetailPanel.tsx
@@ -414,6 +414,9 @@ export function SessionDetailPanel({ sessionId, onBack }: SessionDetailPanelProp
   
   // 分割ページ選択時の並行リクエストを管理するための ref
   const selectPageRequestIdRef = useRef(0);
+  // activeStep を ref で追跡（非同期コールバック内で最新値を参照するため）
+  const activeStepRef = useRef<StepId>(activeStep);
+  useEffect(() => { activeStepRef.current = activeStep; }, [activeStep]);
 
   const loadSession = useCallback(async () => {
     if (!sessionManager || !sessionId) return;
@@ -543,11 +546,11 @@ export function SessionDetailPanel({ sessionId, onBack }: SessionDetailPanelProp
         const client = createDriveClient(accessToken);
         const blob = await client.getFileBlob(page.originalFileId);
         
-        // 最新のリクエストでない場合は破棄
-        if (selectPageRequestIdRef.current !== requestId) {
+        // 最新のリクエストでない、または split ステップを離れた場合は破棄
+        if (selectPageRequestIdRef.current !== requestId || activeStepRef.current !== "split") {
           return;
         }
-        
+
         const url = URL.createObjectURL(blob);
         setSplitImageUrl(url);
         setSplittingPageId(page.id);

--- a/src/components/SessionDetailPanel.tsx
+++ b/src/components/SessionDetailPanel.tsx
@@ -312,6 +312,7 @@ function SplitPageCard({ page, accessToken, onSelect }: SplitPageCardProps) {
 
     async function loadThumbnail() {
       setLoading(true);
+      setThumbnailUrl(null);
       try {
         const blob = await client.getFileBlob(page.originalFileId);
         if (cancelled) return;

--- a/src/components/SessionDetailPanel.tsx
+++ b/src/components/SessionDetailPanel.tsx
@@ -411,6 +411,9 @@ export function SessionDetailPanel({ sessionId, onBack }: SessionDetailPanelProp
   // 分割用の状態
   const [splittingPageId, setSplittingPageId] = useState<string | null>(null);
   const [splitImageUrl, setSplitImageUrl] = useState<string | null>(null);
+  
+  // 分割ページ選択時の並行リクエストを管理するための ref
+  const selectPageRequestIdRef = useRef(0);
 
   const loadSession = useCallback(async () => {
     if (!sessionManager || !sessionId) return;
@@ -534,15 +537,14 @@ export function SessionDetailPanel({ sessionId, onBack }: SessionDetailPanelProp
       
       // リクエスト ID を生成して並行実行時の競合を回避
       const requestId = Date.now();
-      handleSelectPageForSplit.currentRequestId = requestId;
+      selectPageRequestIdRef.current = requestId;
       
       try {
         const client = createDriveClient(accessToken);
         const blob = await client.getFileBlob(page.originalFileId);
         
         // 最新のリクエストでない場合は破棄
-        if (handleSelectPageForSplit.currentRequestId !== requestId) {
-          URL.revokeObjectURL(URL.createObjectURL(blob));
+        if (selectPageRequestIdRef.current !== requestId) {
           return;
         }
         
@@ -551,16 +553,13 @@ export function SessionDetailPanel({ sessionId, onBack }: SessionDetailPanelProp
         setSplittingPageId(page.id);
       } catch (err) {
         // 最新のリクエストでのエラーのみを表示
-        if (handleSelectPageForSplit.currentRequestId === requestId) {
+        if (selectPageRequestIdRef.current === requestId) {
           setOperationError(err instanceof Error ? err.message : "画像の読み込みに失敗しました。");
         }
       }
     },
     [accessToken],
   );
-  
-  // リクエスト ID を格納するプロパティを追加
-  handleSelectPageForSplit.currentRequestId = 0;
 
   const handleSaveSplit = useCallback(
     async (split: SplitResult) => {

--- a/src/lib/image-processing.ts
+++ b/src/lib/image-processing.ts
@@ -56,6 +56,11 @@ function ensureWorker(): Worker {
   return worker;
 }
 
+/** image-processing.ts で管理する OpenCV Worker インスタンスを取得する。 */
+export function getOpenCVWorker(): Worker {
+  return ensureWorker();
+}
+
 function updateStatus(status: WorkerStatus) {
   workerStatus = status;
   statusListeners.forEach((listener) => listener(status));

--- a/src/lib/paragraph-detection.ts
+++ b/src/lib/paragraph-detection.ts
@@ -1,0 +1,203 @@
+/**
+ * 段落境界検出モジュール。
+ *
+ * OpenCV.js (WASM) の Web Worker を使用して補正済み画像から
+ * 水平罫線・余白を検出し、段落境界のY座標配列を生成する。
+ * 検出結果は ParagraphObject[] / SplitResult に変換される。
+ */
+
+import type { ParagraphObject, SplitResult, CropRect } from "@/types/scan";
+import {
+  initOpenCV,
+  imageToCanvas,
+} from "@/lib/image-processing";
+
+// ---------------------------------------------------------------------------
+// Worker 通信
+// ---------------------------------------------------------------------------
+
+type WorkerImageData = {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+};
+
+let taskIdCounter = 0;
+
+function getBasePath(): string {
+  return process.env.NEXT_PUBLIC_BASE_PATH || "";
+}
+
+function ensureWorker(): Worker {
+  // image-processing.ts と同一の Worker を共有する
+  const basePath = getBasePath();
+  return new Worker(`${basePath}/opencv-worker.js`);
+}
+
+type ParagraphBoundariesResult = {
+  splitYs: number[];
+};
+
+/** Worker に段落境界検出タスクを送信し、結果を取得する。 */
+function workerDetectParagraphs(
+  imageData: WorkerImageData,
+  options?: {
+    minLineLength?: number;
+    maxAngleDeg?: number;
+    whitespaceThreshold?: number;
+  },
+): Promise<ParagraphBoundariesResult> {
+  return new Promise((resolve, reject) => {
+    const w = ensureWorker();
+    const id = `para-${++taskIdCounter}`;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const cleanup = () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      w.removeEventListener("message", handler);
+      w.removeEventListener("error", errorHandler);
+      w.removeEventListener("messageerror", errorHandler);
+    };
+
+    const handler = (e: MessageEvent) => {
+      if (e.data.id !== id) return;
+      cleanup();
+      if (e.data.type === "result") {
+        resolve(e.data.paragraphBoundaries as ParagraphBoundariesResult);
+      } else if (e.data.type === "error") {
+        reject(new Error(e.data.error));
+      }
+    };
+
+    const errorHandler = () => {
+      cleanup();
+      reject(new Error("Worker error during paragraph detection"));
+    };
+
+    w.addEventListener("message", handler);
+    w.addEventListener("error", errorHandler);
+    w.addEventListener("messageerror", errorHandler);
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error("段落境界検出がタイムアウトしました。"));
+    }, 30_000);
+
+    const copy = {
+      data: new Uint8ClampedArray(imageData.data),
+      width: imageData.width,
+      height: imageData.height,
+    };
+    w.postMessage({ type: "init" });
+    w.postMessage({ type: "detectParagraphs", id, imageData: copy, options }, [copy.data.buffer]);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 公開 API
+// ---------------------------------------------------------------------------
+
+/** 段落境界検出のオプション。 */
+export type DetectParagraphsOptions = {
+  /** 最小線分長（ピクセル）。画像幅に対する比率。デフォルト: 0.15 */
+  minLineLengthRatio?: number;
+  /** 水平と判定する最大角度（度）。デフォルト: 15 */
+  maxAngleDeg?: number;
+  /** 余白と判定する投射密度の閾値（0〜1）。デフォルト: 0.03 */
+  whitespaceThreshold?: number;
+};
+
+/**
+ * 画像から段落境界のY座標配列を検出する。
+ * OpenCV.js の HoughLinesP で水平罫線を、行投射密度で余白を検出する。
+ */
+export async function detectParagraphs(
+  source: HTMLImageElement | HTMLCanvasElement | ImageBitmap,
+  options?: DetectParagraphsOptions,
+): Promise<number[]> {
+  await initOpenCV();
+
+  const canvas = source instanceof HTMLCanvasElement ? source : imageToCanvas(source);
+  const ctx = canvas.getContext("2d")!;
+  const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+
+  const workerImageData: WorkerImageData = {
+    data: imgData.data,
+    width: imgData.width,
+    height: imgData.height,
+  };
+
+  const minLineLength = options?.minLineLengthRatio
+    ? workerImageData.width * options.minLineLengthRatio
+    : undefined;
+
+  const result = await workerDetectParagraphs(workerImageData, {
+    minLineLength,
+    maxAngleDeg: options?.maxAngleDeg,
+    whitespaceThreshold: options?.whitespaceThreshold,
+  });
+
+  return result.splitYs;
+}
+
+/** 一意のIDを生成する。 */
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+/**
+ * 分割Y座標配列から ParagraphObject[] を生成する。
+ *
+ * splitYs は昇順のY座標配列。先頭に0、末尾にimageHeightを補完し、
+ * 隣接するY座標間を段落の CropRect とする。
+ */
+export function splitYsToParagraphs(
+  splitYs: number[],
+  imageWidth: number,
+  imageHeight: number,
+): ParagraphObject[] {
+  // 0 と imageHeight を含めた境界点を生成
+  const boundaries = [0, ...splitYs.filter((y) => y > 0 && y < imageHeight), imageHeight];
+
+  return boundaries.slice(0, -1).map((topY, i) => {
+    const bottomY = boundaries[i + 1];
+    const height = Math.max(1, bottomY - topY);
+    const cropRect: CropRect = {
+      x: 0,
+      y: topY,
+      width: imageWidth,
+      height,
+    };
+    return {
+      id: generateId(),
+      order: i,
+      cropRect,
+    };
+  });
+}
+
+/**
+ * 段落境界検出を実行し、ParagraphObject[] を生成する。
+ * 自動検出の全工程をまとめたヘルパー。
+ */
+export async function autoDetectParagraphs(
+  source: HTMLImageElement | HTMLCanvasElement | ImageBitmap,
+  options?: DetectParagraphsOptions,
+): Promise<ParagraphObject[]> {
+  const canvas = source instanceof HTMLCanvasElement ? source : imageToCanvas(source);
+  const splitYs = await detectParagraphs(source, options);
+  return splitYsToParagraphs(splitYs, canvas.width, canvas.height);
+}
+
+/**
+ * ParagraphObject[] から SplitResult を生成する。
+ */
+export function createSplitResult(paragraphs: ParagraphObject[]): SplitResult {
+  return {
+    splitAt: new Date().toISOString(),
+    paragraphs,
+  };
+}

--- a/src/lib/paragraph-detection.ts
+++ b/src/lib/paragraph-detection.ts
@@ -89,14 +89,11 @@ function workerDetectParagraphs(
       reject(new Error("段落境界検出がタイムアウトしました。"));
     }, 30_000);
 
-    const copy = {
-      data: new Uint8ClampedArray(imageData.data),
-      width: imageData.width,
-      height: imageData.height,
-    };
-    
     try {
-      w.postMessage({ type: "detectParagraphs", id, imageData: copy, options }, [copy.data.buffer]);
+      w.postMessage(
+        { type: "detectParagraphs", id, imageData, options },
+        [imageData.data.buffer],
+      );
     } catch (error) {
       cleanup();
       reject(error instanceof Error ? error : new Error(String(error)));

--- a/src/lib/paragraph-detection.ts
+++ b/src/lib/paragraph-detection.ts
@@ -158,8 +158,9 @@ export function splitYsToParagraphs(
   imageWidth: number,
   imageHeight: number,
 ): ParagraphObject[] {
-  // 0 と imageHeight を含めた境界点を生成
-  const boundaries = [0, ...splitYs.filter((y) => y > 0 && y < imageHeight), imageHeight];
+  // 昇順ソート・重複除去した上で 0/imageHeight を付与して境界を生成
+  const sorted = [...new Set(splitYs.filter((y) => y > 0 && y < imageHeight))].sort((a, b) => a - b);
+  const boundaries = [0, ...sorted, imageHeight];
 
   return boundaries.slice(0, -1).map((topY, i) => {
     const bottomY = boundaries[i + 1];

--- a/src/lib/paragraph-detection.ts
+++ b/src/lib/paragraph-detection.ts
@@ -10,6 +10,7 @@ import type { ParagraphObject, SplitResult, CropRect } from "@/types/scan";
 import {
   initOpenCV,
   imageToCanvas,
+  getOpenCVWorker,
 } from "@/lib/image-processing";
 
 // ---------------------------------------------------------------------------
@@ -24,16 +25,6 @@ type WorkerImageData = {
 
 let taskIdCounter = 0;
 
-function getBasePath(): string {
-  return process.env.NEXT_PUBLIC_BASE_PATH || "";
-}
-
-function ensureWorker(): Worker {
-  // image-processing.ts と同一の Worker を共有する
-  const basePath = getBasePath();
-  return new Worker(`${basePath}/opencv-worker.js`);
-}
-
 type ParagraphBoundariesResult = {
   splitYs: number[];
 };
@@ -47,7 +38,7 @@ function workerDetectParagraphs(
   },
 ): Promise<ParagraphBoundariesResult> {
   return new Promise((resolve, reject) => {
-    const w = ensureWorker();
+    const w = getOpenCVWorker();
     const id = `para-${++taskIdCounter}`;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -90,7 +81,6 @@ function workerDetectParagraphs(
       width: imageData.width,
       height: imageData.height,
     };
-    w.postMessage({ type: "init" });
     w.postMessage({ type: "detectParagraphs", id, imageData: copy, options }, [copy.data.buffer]);
   });
 }

--- a/src/lib/paragraph-detection.ts
+++ b/src/lib/paragraph-detection.ts
@@ -48,11 +48,17 @@ function workerDetectParagraphs(
         timeoutId = null;
       }
       w.removeEventListener("message", handler);
-      w.removeEventListener("error", errorHandler);
-      w.removeEventListener("messageerror", errorHandler);
+      w.removeEventListener("error", workerErrorHandler);
+      w.removeEventListener("messageerror", workerErrorHandler);
     };
 
     const handler = (e: MessageEvent) => {
+      // id なしのグローバルエラー（OpenCV 初期化失敗など）もタスクに伝播させる
+      if (e.data.type === "error" && !e.data.id) {
+        cleanup();
+        reject(new Error(e.data.error ?? "Worker error"));
+        return;
+      }
       if (e.data.id !== id) return;
       cleanup();
       if (e.data.type === "result") {
@@ -62,14 +68,21 @@ function workerDetectParagraphs(
       }
     };
 
-    const errorHandler = () => {
+    // Worker クラッシュ・応答不能時にリスナーが残らないよう reject して解放する
+    const workerErrorHandler = (e: ErrorEvent | MessageEvent) => {
       cleanup();
-      reject(new Error("Worker error during paragraph detection"));
+      const errorMessage =
+        e.type === "messageerror"
+          ? `Worker messageerror: could not deserialize message (type=${e.type})`
+          : e instanceof ErrorEvent && e.message
+            ? e.message
+            : "Worker error";
+      reject(new Error(errorMessage));
     };
 
     w.addEventListener("message", handler);
-    w.addEventListener("error", errorHandler);
-    w.addEventListener("messageerror", errorHandler);
+    w.addEventListener("error", workerErrorHandler);
+    w.addEventListener("messageerror", workerErrorHandler);
 
     timeoutId = setTimeout(() => {
       cleanup();
@@ -81,7 +94,13 @@ function workerDetectParagraphs(
       width: imageData.width,
       height: imageData.height,
     };
-    w.postMessage({ type: "detectParagraphs", id, imageData: copy, options }, [copy.data.buffer]);
+    
+    try {
+      w.postMessage({ type: "detectParagraphs", id, imageData: copy, options }, [copy.data.buffer]);
+    } catch (error) {
+      cleanup();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
   });
 }
 
@@ -171,7 +190,7 @@ export async function autoDetectParagraphs(
   options?: DetectParagraphsOptions,
 ): Promise<ParagraphObject[]> {
   const canvas = source instanceof HTMLCanvasElement ? source : imageToCanvas(source);
-  const splitYs = await detectParagraphs(source, options);
+  const splitYs = await detectParagraphs(canvas, options);
   return splitYsToParagraphs(splitYs, canvas.width, canvas.height);
 }
 

--- a/src/lib/paragraph-detection.ts
+++ b/src/lib/paragraph-detection.ts
@@ -42,9 +42,8 @@ type ParagraphBoundariesResult = {
 function workerDetectParagraphs(
   imageData: WorkerImageData,
   options?: {
-    minLineLength?: number;
-    maxAngleDeg?: number;
-    whitespaceThreshold?: number;
+    minGapRatio?: number;
+    densityThreshold?: number;
   },
 ): Promise<ParagraphBoundariesResult> {
   return new Promise((resolve, reject) => {
@@ -102,17 +101,16 @@ function workerDetectParagraphs(
 
 /** 段落境界検出のオプション。 */
 export type DetectParagraphsOptions = {
-  /** 最小線分長（ピクセル）。画像幅に対する比率。デフォルト: 0.15 */
-  minLineLengthRatio?: number;
-  /** 水平と判定する最大角度（度）。デフォルト: 15 */
-  maxAngleDeg?: number;
-  /** 余白と判定する投射密度の閾値（0〜1）。デフォルト: 0.03 */
-  whitespaceThreshold?: number;
+  /** 段落間の最小ギャップ高さ（画像高さに対する比率）。デフォルト: 0.03 */
+  minGapRatio?: number;
+  /** テキスト密度の閾値（0〜1）。これ以下を余白と判定。デフォルト: 0.05 */
+  densityThreshold?: number;
 };
 
 /**
  * 画像から段落境界のY座標配列を検出する。
- * OpenCV.js の HoughLinesP で水平罫線を、行投射密度で余白を検出する。
+ * 形態素演算でテキスト領域を結合し、投射密度の大きな谷を段落境界とする。
+ * 手帳の罫線はノイズとして除去される。
  */
 export async function detectParagraphs(
   source: HTMLImageElement | HTMLCanvasElement | ImageBitmap,
@@ -130,14 +128,9 @@ export async function detectParagraphs(
     height: imgData.height,
   };
 
-  const minLineLength = options?.minLineLengthRatio
-    ? workerImageData.width * options.minLineLengthRatio
-    : undefined;
-
   const result = await workerDetectParagraphs(workerImageData, {
-    minLineLength,
-    maxAngleDeg: options?.maxAngleDeg,
-    whitespaceThreshold: options?.whitespaceThreshold,
+    minGapRatio: options?.minGapRatio,
+    densityThreshold: options?.densityThreshold,
   });
 
   return result.splitYs;

--- a/src/lib/session-manager.ts
+++ b/src/lib/session-manager.ts
@@ -2,7 +2,7 @@ import { DriveClient } from "./drive-client";
 import { DriveNotFoundError } from "./drive-errors";
 import { SettingsManager } from "./settings-manager";
 import { IndexManager } from "./index-manager";
-import type { ScanSession, ScanPage, CorrectionResult } from "@/types/scan";
+import type { ScanSession, ScanPage, CorrectionResult, SplitResult } from "@/types/scan";
 
 const SESSION_FILE_PREFIX = "session_";
 
@@ -235,6 +235,20 @@ export class SessionManager {
       }
 
       page.correction = correction;
+      await this.saveSession(session);
+    });
+  }
+
+  /** ページの段落分割結果を更新して保存する。 */
+  async updatePageSplit(sessionId: string, pageId: string, split: SplitResult): Promise<void> {
+    await this.runSerialized(sessionId, async () => {
+      const { session } = await this.loadSessionWithFileId(sessionId);
+      const page = session.pages.find((p) => p.id === pageId);
+      if (!page) {
+        throw new Error(`ページ ${pageId} がセッション ${sessionId} に見つかりません。`);
+      }
+
+      page.split = split;
       await this.saveSession(session);
     });
   }


### PR DESCRIPTION
## 概要

Issue #17 の段落分割モジュールを実装しました。
補正済み（または元）画像からテキストブロックを結合し、垂直投射密度から余白領域を検出して段落境界を自動検出し、ユーザーが手動で分割線の追加・削除・調整できるUIを提供します。

Closes #17

## 変更内容

### 新規ファイル
- **src/lib/paragraph-detection.ts** — 段落境界検出・SplitResult 生成のユーティリティモジュール
  - `detectParagraphs()`: OpenCV.js Worker 経由でモルフォロジー（クロージング）+ 垂直投射による段落境界検出
  - `splitYsToParagraphs()`: Y座標配列 → ParagraphObject[] 変換
  - `createSplitResult()`: ParagraphObject[] → SplitResult 生成

- **src/components/ParagraphCard.tsx** — 段落ごとの切り抜きプレビューコンポーネント
  - Canvas API で指定領域を crop して表示
  - 上下移動・削除操作を提供

- **src/components/ParagraphSplitUI.tsx** — 段落分割のメインUIコンポーネント
  - 分割線オーバーレイ表示（SVG 破線 + ドラッグハンドル）
  - 分割線の手動追加（画像クリック）・削除・ドラッグ移動
  - OpenCV.js による自動検出（モルフォロジー + 垂直投射）
  - 各段落の切り抜きプレビュー（ParagraphCard）
  - 「分割なしで保存」「全消去」ボタン

### 変更ファイル
- **public/opencv-worker.js** — `detectParagraphs` メッセージハンドラを追加
  - ガウシアンブラーで罫線をぼかして消す
  - モルフォロジークロージングで水平方向に文字を結合してテキストブロックにする
  - 垂直投射から余白領域を検出
  - 連続する余白領域の中心を段落境界として抽出

- **src/lib/session-manager.ts** — `updatePageSplit()` メソッドを追加

- **src/components/SessionDetailPanel.tsx** — 段落分割ステップを統合
  - StepNav に段落分割ステップの進捗バッジを表示
  - SplitPageCard コンポーネントを追加
  - 段落分割ステップのプレースホルダーを ParagraphSplitUI に差し替え

## 受け入れ条件の対応状況
- [x] OpenCV.jsによる段落境界自動検出（テキストブロック結合・余白検出）
- [x] 分割プレビューUI（画像上に分割線をオーバーレイ表示）
- [x] 分割線の手動追加・削除・ドラッグ移動
- [x] 各段落の切り抜きプレビュー（Canvas crop）
- [x] SplitResultとして座標配列をメタデータに保存
- [x] 「再検出」「手動分割のみ」の選択

---
_Agent-generated PR. All changes were created by an AI assistant (OpenHands) on behalf of the user._