### PR TITLE
feat(#19): 写真インポート機能（PhotoImporter / PhotoPicker / PhotoCard）

### DIFF
--- a/src/app/photos/page.tsx
+++ b/src/app/photos/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { AppShell } from "@/components/AppShell";
+import { PhotoPicker } from "@/components/PhotoPicker";
+import { useRequireAuth } from "@/lib/use-require-auth";
+
+export default function PhotosPage() {
+  const { isAuthorized } = useRequireAuth();
+  if (!isAuthorized) return null;
+
+  return (
+    <AppShell>
+      <div className="max-w-4xl mx-auto py-6 px-4">
+        <h1 className="text-xl font-semibold text-slate-800 mb-6">写真インポート</h1>
+        <PhotoPicker />
+      </div>
+    </AppShell>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -11,6 +11,7 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { href: "/sessions", label: "セッション一覧", icon: "📓" },
+  { href: "/photos", label: "写真インポート", icon: "🖼️" },
   { href: "/articles/new", label: "記事を作成", icon: "✏️" },
   { href: "/settings", label: "設定", icon: "⚙️" },
 ];

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -150,6 +150,12 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
     [cropState, getImageNormalizedCoords],
   );
 
+  const onPointerCancel = useCallback(() => {
+    if (cropState.active) {
+      setCropState(INITIAL_CROP);
+    }
+  }, [cropState.active]);
+
   const openCropUI = () => {
     // 開き直すたびに最新の photo.cropRect を pendingCrop に同期
     setPendingCrop(photo.cropRect ?? null);
@@ -220,10 +226,11 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
     <div className="bg-white rounded-lg shadow border border-gray-200 overflow-hidden flex flex-col">
       {/* サムネイル */}
       <div
-        className={`relative bg-gray-100 aspect-square overflow-hidden ${showCropUI ? "cursor-crosshair select-none" : ""}`}
+        className={`relative bg-gray-100 aspect-square overflow-hidden ${showCropUI ? "cursor-crosshair select-none touch-none" : ""}`}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
+        onPointerCancel={onPointerCancel}
       >
         {thumbnailUrl ? (
           <img

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import type { PhotoObject } from "@/types/photo";
+import type { CropRect } from "@/types/scan";
+
+export type PhotoCardProps = {
+  photo: PhotoObject;
+  /** サムネイル画像の URL。Drive の場合は認証付き fetch が必要なため外部から渡す。 */
+  thumbnailUrl?: string;
+  onDelete?: (id: string) => void;
+  onCropChange?: (id: string, cropRect: CropRect) => void;
+};
+
+type CropState = {
+  active: boolean;
+  startX: number;
+  startY: number;
+  currentX: number;
+  currentY: number;
+};
+
+const INITIAL_CROP: CropState = {
+  active: false,
+  startX: 0,
+  startY: 0,
+  currentX: 0,
+  currentY: 0,
+};
+
+export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: PhotoCardProps) {
+  const [showCropUI, setShowCropUI] = useState(false);
+  const [cropState, setCropState] = useState<CropState>(INITIAL_CROP);
+  const [pendingCrop, setPendingCrop] = useState<CropRect | null>(
+    photo.cropRect ?? null,
+  );
+  const imgRef = useRef<HTMLImageElement | null>(null);
+
+  const sourceLabel =
+    photo.sourceType === "google_photos" ? "Google Photos" : "Google Drive";
+
+  const formattedDate = photo.takenAt
+    ? new Date(photo.takenAt).toLocaleString("ja-JP", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : null;
+
+  // ------------------------------------------------------------------
+  // crop UI helpers
+  // ------------------------------------------------------------------
+
+  const getRelativeCoords = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>): { x: number; y: number } => {
+      const rect = e.currentTarget.getBoundingClientRect();
+      return {
+        x: Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width)),
+        y: Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height)),
+      };
+    },
+    [],
+  );
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!showCropUI) return;
+      const { x, y } = getRelativeCoords(e);
+      setCropState({ active: true, startX: x, startY: y, currentX: x, currentY: y });
+    },
+    [showCropUI, getRelativeCoords],
+  );
+
+  const onMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!cropState.active) return;
+      const { x, y } = getRelativeCoords(e);
+      setCropState((s: CropState) => ({ ...s, currentX: x, currentY: y }));
+    },
+    [cropState.active, getRelativeCoords],
+  );
+
+  const onMouseUp = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!cropState.active) return;
+      const { x, y } = getRelativeCoords(e);
+      const x1 = Math.min(cropState.startX, x);
+      const y1 = Math.min(cropState.startY, y);
+      const x2 = Math.max(cropState.startX, x);
+      const y2 = Math.max(cropState.startY, y);
+      const crop: CropRect = { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
+      setPendingCrop(crop);
+      setCropState(INITIAL_CROP);
+    },
+    [cropState, getRelativeCoords],
+  );
+
+  const applyCrop = () => {
+    if (pendingCrop) {
+      onCropChange?.(photo.id, pendingCrop);
+    }
+    setShowCropUI(false);
+  };
+
+  const cancelCrop = () => {
+    setPendingCrop(photo.cropRect ?? null);
+    setShowCropUI(false);
+    setCropState(INITIAL_CROP);
+  };
+
+  // Normalize crop rect for display (handle reversed drag directions)
+  const displayCrop = cropState.active
+    ? {
+        x: Math.min(cropState.startX, cropState.currentX),
+        y: Math.min(cropState.startY, cropState.currentY),
+        width: Math.abs(cropState.currentX - cropState.startX),
+        height: Math.abs(cropState.currentY - cropState.startY),
+      }
+    : pendingCrop;
+
+  return (
+    <div className="bg-white rounded-lg shadow border border-gray-200 overflow-hidden flex flex-col">
+      {/* サムネイル */}
+      <div
+        className={`relative bg-gray-100 aspect-square overflow-hidden ${showCropUI ? "cursor-crosshair select-none" : ""}`}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+      >
+        {thumbnailUrl ? (
+          <img
+            ref={imgRef}
+            src={thumbnailUrl}
+            alt={photo.title ?? "photo"}
+            className="w-full h-full object-cover pointer-events-none"
+            draggable={false}
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-gray-400 text-sm">
+            No image
+          </div>
+        )}
+
+        {/* クロップ選択オーバーレイ */}
+        {showCropUI && displayCrop && displayCrop.width > 0.01 && displayCrop.height > 0.01 && (
+          <div
+            className="absolute border-2 border-blue-400 bg-blue-400/20 pointer-events-none"
+            style={{
+              left: `${displayCrop.x * 100}%`,
+              top: `${displayCrop.y * 100}%`,
+              width: `${displayCrop.width * 100}%`,
+              height: `${displayCrop.height * 100}%`,
+            }}
+          />
+        )}
+
+        {/* ソースバッジ */}
+        <span className="absolute top-1 left-1 text-xs bg-black/50 text-white px-1.5 py-0.5 rounded">
+          {sourceLabel}
+        </span>
+      </div>
+
+      {/* メタデータ */}
+      <div className="p-3 flex flex-col gap-1 flex-1">
+        <p className="text-sm font-medium text-gray-800 truncate" title={photo.title}>
+          {photo.title ?? "(無題)"}
+        </p>
+        {formattedDate && (
+          <p className="text-xs text-gray-500">{formattedDate}</p>
+        )}
+        {photo.cropRect && !showCropUI && (
+          <p className="text-xs text-blue-500">切り抜き済み</p>
+        )}
+      </div>
+
+      {/* アクション */}
+      <div className="px-3 pb-3 flex gap-2">
+        {onCropChange && !showCropUI && (
+          <button
+            onClick={() => setShowCropUI(true)}
+            className="text-xs px-2 py-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 transition-colors"
+          >
+            切り抜き
+          </button>
+        )}
+        {showCropUI && (
+          <>
+            <button
+              onClick={applyCrop}
+              disabled={!pendingCrop}
+              className="text-xs px-2 py-1 rounded bg-blue-500 hover:bg-blue-600 text-white transition-colors disabled:opacity-50"
+            >
+              適用
+            </button>
+            <button
+              onClick={cancelCrop}
+              className="text-xs px-2 py-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 transition-colors"
+            >
+              キャンセル
+            </button>
+          </>
+        )}
+        {onDelete && !showCropUI && (
+          <button
+            onClick={() => onDelete(photo.id)}
+            className="text-xs px-2 py-1 rounded bg-red-50 hover:bg-red-100 text-red-600 transition-colors ml-auto"
+          >
+            削除
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -204,6 +204,8 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
     [],
   );
 
+  // cropState も pendingCrop も実画像正規化座標（0..1）なので、
+  // ドラッグ中・確定後を問わず常に toContainerRect() でコンテナ相対に変換して描画する
   const rawDisplayCrop: NormalizedCropRect | null = cropState.active
     ? {
         x: Math.min(cropState.startX, cropState.currentX),
@@ -213,10 +215,7 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
       }
     : pendingCrop;
 
-  // 表示用にコンテナ相対座標に変換（ドラッグ中は既にコンテナ相対なので変換不要）
-  const displayCrop = rawDisplayCrop && !cropState.active
-    ? toContainerRect(rawDisplayCrop)
-    : rawDisplayCrop;
+  const displayCrop = rawDisplayCrop ? toContainerRect(rawDisplayCrop) : null;
 
   return (
     <div className="bg-white rounded-lg shadow border border-gray-200 overflow-hidden flex flex-col">

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -106,16 +106,21 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
     [],
   );
 
-  const onMouseDown = useCallback(
-    (e: MouseEventLike) => {
+  // Pointer Events + setPointerCapture でコンテナ外へのドラッグも確実に捕捉する
+  const onPointerDown = useCallback(
+    (e: MouseEventLike & { pointerId?: number; currentTarget: Element }) => {
       if (!showCropUI) return;
+      // ポインタキャプチャでコンテナ外の move/up も受け取る
+      if (typeof (e.currentTarget as HTMLElement).setPointerCapture === "function" && e.pointerId != null) {
+        (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      }
       const { x, y } = getImageNormalizedCoords(e);
       setCropState({ active: true, startX: x, startY: y, currentX: x, currentY: y });
     },
     [showCropUI, getImageNormalizedCoords],
   );
 
-  const onMouseMove = useCallback(
+  const onPointerMove = useCallback(
     (e: MouseEventLike) => {
       if (!cropState.active) return;
       const { x, y } = getImageNormalizedCoords(e);
@@ -124,7 +129,7 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
     [cropState.active, getImageNormalizedCoords],
   );
 
-  const onMouseUp = useCallback(
+  const onPointerUp = useCallback(
     (e: MouseEventLike) => {
       if (!cropState.active) return;
       const { x, y } = getImageNormalizedCoords(e);
@@ -144,12 +149,6 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
     },
     [cropState, getImageNormalizedCoords],
   );
-
-  const onMouseLeave = useCallback(() => {
-    if (cropState.active) {
-      setCropState(INITIAL_CROP);
-    }
-  }, [cropState.active]);
 
   const openCropUI = () => {
     // 開き直すたびに最新の photo.cropRect を pendingCrop に同期
@@ -222,10 +221,9 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
       {/* サムネイル */}
       <div
         className={`relative bg-gray-100 aspect-square overflow-hidden ${showCropUI ? "cursor-crosshair select-none" : ""}`}
-        onMouseDown={onMouseDown}
-        onMouseMove={onMouseMove}
-        onMouseUp={onMouseUp}
-        onMouseLeave={onMouseLeave}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
       >
         {thumbnailUrl ? (
           <img

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -1,15 +1,14 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
-import type { PhotoObject } from "@/types/photo";
-import type { CropRect } from "@/types/scan";
+import type { PhotoObject, NormalizedCropRect } from "@/types/photo";
 
 export type PhotoCardProps = {
   photo: PhotoObject;
   /** サムネイル画像の URL。Drive の場合は認証付き fetch が必要なため外部から渡す。 */
   thumbnailUrl?: string;
   onDelete?: (id: string) => void;
-  onCropChange?: (id: string, cropRect: CropRect) => void;
+  onCropChange?: (id: string, cropRect: NormalizedCropRect) => void;
 };
 
 type CropState = {
@@ -31,7 +30,7 @@ const INITIAL_CROP: CropState = {
 export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: PhotoCardProps) {
   const [showCropUI, setShowCropUI] = useState(false);
   const [cropState, setCropState] = useState<CropState>(INITIAL_CROP);
-  const [pendingCrop, setPendingCrop] = useState<CropRect | null>(
+  const [pendingCrop, setPendingCrop] = useState<NormalizedCropRect | null>(
     photo.cropRect ?? null,
   );
   const imgRef = useRef<HTMLImageElement | null>(null);
@@ -90,7 +89,7 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
       const y1 = Math.min(cropState.startY, y);
       const x2 = Math.max(cropState.startX, x);
       const y2 = Math.max(cropState.startY, y);
-      const crop: CropRect = { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
+      const crop: NormalizedCropRect = { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
       setPendingCrop(crop);
       setCropState(INITIAL_CROP);
     },

--- a/src/components/PhotoCard.tsx
+++ b/src/components/PhotoCard.tsx
@@ -19,6 +19,13 @@ type CropState = {
   currentY: number;
 };
 
+/** React.MouseEvent を使わずに必要なフィールドだけ定義した最小型。 */
+type MouseEventLike = {
+  clientX: number;
+  clientY: number;
+  currentTarget: Element;
+};
+
 const INITIAL_CROP: CropState = {
   active: false,
   startX: 0,
@@ -26,6 +33,8 @@ const INITIAL_CROP: CropState = {
   currentX: 0,
   currentY: 0,
 };
+
+const MIN_CROP_SIZE = 0.01;
 
 export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: PhotoCardProps) {
   const [showCropUI, setShowCropUI] = useState(false);
@@ -52,49 +61,101 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
   // crop UI helpers
   // ------------------------------------------------------------------
 
-  const getRelativeCoords = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>): { x: number; y: number } => {
-      const rect = e.currentTarget.getBoundingClientRect();
+  /**
+   * コンテナ上のマウス座標を実画像の正規化座標（0..1）に変換する。
+   * object-cover によるスケール/オフセットを考慮する。
+   * 画像が未ロード（naturalWidth=0）の場合はコンテナ相対座標にフォールバック。
+   */
+  const getImageNormalizedCoords = useCallback(
+    (e: MouseEventLike): { x: number; y: number } => {
+      const container = e.currentTarget as HTMLElement;
+      const rect = container.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      const cy = e.clientY - rect.top;
+      const cw = rect.width;
+      const ch = rect.height;
+
+      const img = imgRef.current;
+      const nw = img?.naturalWidth ?? 0;
+      const nh = img?.naturalHeight ?? 0;
+
+      if (!img || nw === 0 || nh === 0) {
+        // 画像未ロード時はコンテナ相対座標
+        return {
+          x: Math.min(1, Math.max(0, cx / cw)),
+          y: Math.min(1, Math.max(0, cy / ch)),
+        };
+      }
+
+      // object-cover のスケール（コンテナを完全に埋める最小スケール）
+      const scale = Math.max(cw / nw, ch / nh);
+      const renderedW = nw * scale;
+      const renderedH = nh * scale;
+      const offsetX = (cw - renderedW) / 2;
+      const offsetY = (ch - renderedH) / 2;
+
+      // コンテナ座標 → 画像ピクセル座標 → 正規化
+      const ix = (cx - offsetX) / scale;
+      const iy = (cy - offsetY) / scale;
+
       return {
-        x: Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width)),
-        y: Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height)),
+        x: Math.min(1, Math.max(0, ix / nw)),
+        y: Math.min(1, Math.max(0, iy / nh)),
       };
     },
     [],
   );
 
   const onMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: MouseEventLike) => {
       if (!showCropUI) return;
-      const { x, y } = getRelativeCoords(e);
+      const { x, y } = getImageNormalizedCoords(e);
       setCropState({ active: true, startX: x, startY: y, currentX: x, currentY: y });
     },
-    [showCropUI, getRelativeCoords],
+    [showCropUI, getImageNormalizedCoords],
   );
 
   const onMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: MouseEventLike) => {
       if (!cropState.active) return;
-      const { x, y } = getRelativeCoords(e);
+      const { x, y } = getImageNormalizedCoords(e);
       setCropState((s: CropState) => ({ ...s, currentX: x, currentY: y }));
     },
-    [cropState.active, getRelativeCoords],
+    [cropState.active, getImageNormalizedCoords],
   );
 
   const onMouseUp = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: MouseEventLike) => {
       if (!cropState.active) return;
-      const { x, y } = getRelativeCoords(e);
+      const { x, y } = getImageNormalizedCoords(e);
       const x1 = Math.min(cropState.startX, x);
       const y1 = Math.min(cropState.startY, y);
       const x2 = Math.max(cropState.startX, x);
       const y2 = Math.max(cropState.startY, y);
-      const crop: NormalizedCropRect = { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
-      setPendingCrop(crop);
+      const w = x2 - x1;
+      const h = y2 - y1;
+      // クリックのみ（極小）の選択は無効
+      if (w < MIN_CROP_SIZE || h < MIN_CROP_SIZE) {
+        setPendingCrop(null);
+      } else {
+        setPendingCrop({ x: x1, y: y1, width: w, height: h });
+      }
       setCropState(INITIAL_CROP);
     },
-    [cropState, getRelativeCoords],
+    [cropState, getImageNormalizedCoords],
   );
+
+  const onMouseLeave = useCallback(() => {
+    if (cropState.active) {
+      setCropState(INITIAL_CROP);
+    }
+  }, [cropState.active]);
+
+  const openCropUI = () => {
+    // 開き直すたびに最新の photo.cropRect を pendingCrop に同期
+    setPendingCrop(photo.cropRect ?? null);
+    setShowCropUI(true);
+  };
 
   const applyCrop = () => {
     if (pendingCrop) {
@@ -109,8 +170,41 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
     setCropState(INITIAL_CROP);
   };
 
-  // Normalize crop rect for display (handle reversed drag directions)
-  const displayCrop = cropState.active
+  /**
+   * オーバーレイ表示用の crop rect。
+   * ドラッグ中は cropState から計算、確定後は pendingCrop を使う。
+   * 座標は object-cover のコンテナ相対（0..1）に逆変換して表示する。
+   */
+  const toContainerRect = useCallback(
+    (r: NormalizedCropRect) => {
+      const img = imgRef.current;
+      const nw = img?.naturalWidth ?? 0;
+      const nh = img?.naturalHeight ?? 0;
+      const containerEl = img?.parentElement;
+
+      if (!img || nw === 0 || nh === 0 || !containerEl) {
+        return r;
+      }
+
+      const cw = containerEl.getBoundingClientRect().width;
+      const ch = containerEl.getBoundingClientRect().height;
+      const scale = Math.max(cw / nw, ch / nh);
+      const renderedW = nw * scale;
+      const renderedH = nh * scale;
+      const offsetX = (cw - renderedW) / 2;
+      const offsetY = (ch - renderedH) / 2;
+
+      return {
+        x: (r.x * nw * scale + offsetX) / cw,
+        y: (r.y * nh * scale + offsetY) / ch,
+        width: (r.width * nw * scale) / cw,
+        height: (r.height * nh * scale) / ch,
+      };
+    },
+    [],
+  );
+
+  const rawDisplayCrop: NormalizedCropRect | null = cropState.active
     ? {
         x: Math.min(cropState.startX, cropState.currentX),
         y: Math.min(cropState.startY, cropState.currentY),
@@ -118,6 +212,11 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
         height: Math.abs(cropState.currentY - cropState.startY),
       }
     : pendingCrop;
+
+  // 表示用にコンテナ相対座標に変換（ドラッグ中は既にコンテナ相対なので変換不要）
+  const displayCrop = rawDisplayCrop && !cropState.active
+    ? toContainerRect(rawDisplayCrop)
+    : rawDisplayCrop;
 
   return (
     <div className="bg-white rounded-lg shadow border border-gray-200 overflow-hidden flex flex-col">
@@ -127,6 +226,7 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
         onMouseDown={onMouseDown}
         onMouseMove={onMouseMove}
         onMouseUp={onMouseUp}
+        onMouseLeave={onMouseLeave}
       >
         {thumbnailUrl ? (
           <img
@@ -143,7 +243,7 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
         )}
 
         {/* クロップ選択オーバーレイ */}
-        {showCropUI && displayCrop && displayCrop.width > 0.01 && displayCrop.height > 0.01 && (
+        {showCropUI && displayCrop && displayCrop.width > MIN_CROP_SIZE && displayCrop.height > MIN_CROP_SIZE && (
           <div
             className="absolute border-2 border-blue-400 bg-blue-400/20 pointer-events-none"
             style={{
@@ -178,7 +278,7 @@ export function PhotoCard({ photo, thumbnailUrl, onDelete, onCropChange }: Photo
       <div className="px-3 pb-3 flex gap-2">
         {onCropChange && !showCropUI && (
           <button
-            onClick={() => setShowCropUI(true)}
+            onClick={openCropUI}
             className="text-xs px-2 py-1 rounded bg-gray-100 hover:bg-gray-200 text-gray-700 transition-colors"
           >
             切り抜き

--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import {
+  PhotoImporter,
+  type GooglePhotosMediaItem,
+  type DriveImageFile,
+} from "@/lib/photo-importer";
+import { createDriveClient } from "@/lib/drive-client";
+import { IndexManager } from "@/lib/index-manager";
+import { useAuth } from "@/lib/auth-context";
+import type { PhotoObject } from "@/types/photo";
+
+type Tab = "google_photos" | "google_drive";
+
+type PhotoPickerProps = {
+  /** インポート完了時に呼ばれるコールバック。 */
+  onImported?: (photo: PhotoObject) => void;
+};
+
+export function PhotoPicker({ onImported }: PhotoPickerProps) {
+  const { accessToken } = useAuth();
+  const [tab, setTab] = useState<Tab>("google_photos");
+
+  // --- Google Photos state ---
+  const [gpStartDate, setGpStartDate] = useState("");
+  const [gpEndDate, setGpEndDate] = useState("");
+  const [gpItems, setGpItems] = useState<GooglePhotosMediaItem[]>([]);
+  const [gpNextPageToken, setGpNextPageToken] = useState<string | undefined>();
+  const [gpLoading, setGpLoading] = useState(false);
+  const [gpError, setGpError] = useState<string | null>(null);
+
+  // --- Google Drive state ---
+  const [drKeyword, setDrKeyword] = useState("");
+  const [drFiles, setDrFiles] = useState<DriveImageFile[]>([]);
+  const [drNextPageToken, setDrNextPageToken] = useState<string | undefined>();
+  const [drLoading, setDrLoading] = useState(false);
+  const [drError, setDrError] = useState<string | null>(null);
+
+  // --- importing state ---
+  const [importing, setImporting] = useState<string | null>(null);
+
+  const makeImporter = useCallback((): PhotoImporter | null => {
+    if (!accessToken) return null;
+    const client = createDriveClient(accessToken);
+    const indexManager = new IndexManager(client);
+    return new PhotoImporter(client, indexManager, accessToken);
+  }, [accessToken]);
+
+  // ------------------------------------------------------------------
+  // Google Photos 検索
+  // ------------------------------------------------------------------
+
+  const searchGooglePhotos = useCallback(
+    async (append = false) => {
+      const importer = makeImporter();
+      if (!importer) return;
+
+      setGpLoading(true);
+      setGpError(null);
+      try {
+        const result = await importer.searchGooglePhotos({
+          startDate: gpStartDate || undefined,
+          endDate: gpEndDate || undefined,
+          pageToken: append ? gpNextPageToken : undefined,
+        });
+        setGpItems((prev: GooglePhotosMediaItem[]) => (append ? [...prev, ...result.mediaItems] : result.mediaItems));
+        setGpNextPageToken(result.nextPageToken);
+      } catch (e) {
+        setGpError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setGpLoading(false);
+      }
+    },
+    [makeImporter, gpStartDate, gpEndDate, gpNextPageToken],
+  );
+
+  // ------------------------------------------------------------------
+  // Google Drive 検索
+  // ------------------------------------------------------------------
+
+  const searchDriveImages = useCallback(
+    async (append = false) => {
+      const importer = makeImporter();
+      if (!importer) return;
+
+      setDrLoading(true);
+      setDrError(null);
+      try {
+        const result = await importer.searchDriveImages({
+          keyword: drKeyword || undefined,
+          pageToken: append ? drNextPageToken : undefined,
+        });
+        setDrFiles((prev: DriveImageFile[]) => (append ? [...prev, ...result.files] : result.files));
+        setDrNextPageToken(result.nextPageToken);
+      } catch (e) {
+        setDrError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setDrLoading(false);
+      }
+    },
+    [makeImporter, drKeyword, drNextPageToken],
+  );
+
+  // ------------------------------------------------------------------
+  // インポート
+  // ------------------------------------------------------------------
+
+  const importGooglePhoto = useCallback(
+    async (item: GooglePhotosMediaItem) => {
+      const importer = makeImporter();
+      if (!importer) return;
+      setImporting(item.id);
+      try {
+        // IndexManager を load() してから使う
+        const client = createDriveClient(accessToken!);
+        const indexManager = new IndexManager(client);
+        await indexManager.load();
+        const fullImporter = new PhotoImporter(client, indexManager, accessToken!);
+        const photo = await fullImporter.importFromGooglePhotos(item);
+        onImported?.(photo);
+      } catch (e) {
+        alert(`インポートに失敗しました: ${e instanceof Error ? e.message : String(e)}`);
+      } finally {
+        setImporting(null);
+      }
+    },
+    [makeImporter, accessToken, onImported],
+  );
+
+  const importDriveFile = useCallback(
+    async (file: DriveImageFile) => {
+      const importer = makeImporter();
+      if (!importer) return;
+      setImporting(file.id);
+      try {
+        const client = createDriveClient(accessToken!);
+        const indexManager = new IndexManager(client);
+        await indexManager.load();
+        const fullImporter = new PhotoImporter(client, indexManager, accessToken!);
+        const photo = await fullImporter.importFromGoogleDrive(file);
+        onImported?.(photo);
+      } catch (e) {
+        alert(`インポートに失敗しました: ${e instanceof Error ? e.message : String(e)}`);
+      } finally {
+        setImporting(null);
+      }
+    },
+    [makeImporter, accessToken, onImported],
+  );
+
+  // Tab 切り替え時にリセット
+  useEffect(() => {
+    setGpItems([]);
+    setGpNextPageToken(undefined);
+    setDrFiles([]);
+    setDrNextPageToken(undefined);
+  }, [tab]);
+
+  if (!accessToken) {
+    return (
+      <div className="p-4 text-gray-500 text-sm">
+        写真を検索するにはログインが必要です。
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* タブ */}
+      <div className="flex border-b border-gray-200">
+        <button
+          onClick={() => setTab("google_photos")}
+          className={`px-4 py-2 text-sm font-medium transition-colors ${
+            tab === "google_photos"
+              ? "border-b-2 border-blue-500 text-blue-600"
+              : "text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          Google Photos
+        </button>
+        <button
+          onClick={() => setTab("google_drive")}
+          className={`px-4 py-2 text-sm font-medium transition-colors ${
+            tab === "google_drive"
+              ? "border-b-2 border-blue-500 text-blue-600"
+              : "text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          Google Drive
+        </button>
+      </div>
+
+      {/* Google Photos パネル */}
+      {tab === "google_photos" && (
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap gap-2 items-end">
+            <label className="flex flex-col gap-1 text-xs text-gray-600">
+              開始日
+              <input
+                type="date"
+                value={gpStartDate}
+                onChange={(e) => setGpStartDate(e.target.value)}
+                className="border border-gray-300 rounded px-2 py-1 text-sm"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs text-gray-600">
+              終了日
+              <input
+                type="date"
+                value={gpEndDate}
+                onChange={(e) => setGpEndDate(e.target.value)}
+                className="border border-gray-300 rounded px-2 py-1 text-sm"
+              />
+            </label>
+            <button
+              onClick={() => searchGooglePhotos(false)}
+              disabled={gpLoading}
+              className="px-3 py-1.5 bg-blue-500 hover:bg-blue-600 text-white text-sm rounded transition-colors disabled:opacity-50"
+            >
+              {gpLoading ? "検索中…" : "検索"}
+            </button>
+          </div>
+
+          {gpError && (
+            <p className="text-red-500 text-sm">{gpError}</p>
+          )}
+
+          {gpItems.length > 0 && (
+            <>
+              <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+                {gpItems.map((item) => (
+                  <div
+                    key={item.id}
+                    className="relative group rounded overflow-hidden border border-gray-200 bg-gray-50 aspect-square"
+                  >
+                    <img
+                      src={PhotoImporter.getThumbnailUrl(item.baseUrl, 200, 200)}
+                      alt={item.filename}
+                      className="w-full h-full object-cover"
+                    />
+                    <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 flex flex-col items-center justify-center gap-1 transition-opacity">
+                      <p className="text-white text-xs text-center px-1 truncate w-full text-center">
+                        {item.filename}
+                      </p>
+                      <button
+                        onClick={() => importGooglePhoto(item)}
+                        disabled={importing === item.id}
+                        className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded transition-colors disabled:opacity-50"
+                      >
+                        {importing === item.id ? "取り込み中…" : "インポート"}
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {gpNextPageToken && (
+                <button
+                  onClick={() => searchGooglePhotos(true)}
+                  disabled={gpLoading}
+                  className="self-center px-4 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 transition-colors disabled:opacity-50"
+                >
+                  {gpLoading ? "読み込み中…" : "さらに読み込む"}
+                </button>
+              )}
+            </>
+          )}
+
+          {!gpLoading && gpItems.length === 0 && (
+            <p className="text-gray-400 text-sm text-center py-6">
+              日付範囲を指定して検索してください。
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Google Drive パネル */}
+      {tab === "google_drive" && (
+        <div className="flex flex-col gap-3">
+          <div className="flex gap-2 items-end">
+            <label className="flex flex-col gap-1 text-xs text-gray-600 flex-1">
+              ファイル名で検索
+              <input
+                type="text"
+                value={drKeyword}
+                onChange={(e) => setDrKeyword(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && searchDriveImages(false)}
+                placeholder="キーワード（空欄で全件）"
+                className="border border-gray-300 rounded px-2 py-1 text-sm"
+              />
+            </label>
+            <button
+              onClick={() => searchDriveImages(false)}
+              disabled={drLoading}
+              className="px-3 py-1.5 bg-blue-500 hover:bg-blue-600 text-white text-sm rounded transition-colors disabled:opacity-50"
+            >
+              {drLoading ? "検索中…" : "検索"}
+            </button>
+          </div>
+
+          {drError && (
+            <p className="text-red-500 text-sm">{drError}</p>
+          )}
+
+          {drFiles.length > 0 && (
+            <>
+              <div className="flex flex-col gap-1">
+                {drFiles.map((file) => (
+                  <div
+                    key={file.id}
+                    className="flex items-center gap-3 px-3 py-2 rounded border border-gray-200 hover:bg-gray-50"
+                  >
+                    {file.thumbnailLink ? (
+                      <img
+                        src={file.thumbnailLink}
+                        alt={file.name}
+                        className="w-10 h-10 object-cover rounded flex-shrink-0"
+                      />
+                    ) : (
+                      <div className="w-10 h-10 bg-gray-100 rounded flex-shrink-0 flex items-center justify-center text-gray-400 text-xs">
+                        IMG
+                      </div>
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-800 truncate">
+                        {file.name}
+                      </p>
+                      {file.createdTime && (
+                        <p className="text-xs text-gray-500">
+                          {new Date(file.createdTime).toLocaleDateString("ja-JP")}
+                        </p>
+                      )}
+                    </div>
+                    <button
+                      onClick={() => importDriveFile(file)}
+                      disabled={importing === file.id}
+                      className="flex-shrink-0 px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded transition-colors disabled:opacity-50"
+                    >
+                      {importing === file.id ? "取り込み中…" : "インポート"}
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              {drNextPageToken && (
+                <button
+                  onClick={() => searchDriveImages(true)}
+                  disabled={drLoading}
+                  className="self-center px-4 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 transition-colors disabled:opacity-50"
+                >
+                  {drLoading ? "読み込み中…" : "さらに読み込む"}
+                </button>
+              )}
+            </>
+          )}
+
+          {!drLoading && drFiles.length === 0 && (
+            <p className="text-gray-400 text-sm text-center py-6">
+              検索ボタンを押してください。
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -35,6 +35,8 @@ function AuthedThumbnail({
 
   useEffect(() => {
     let cancelled = false;
+    // 新しい fetch を開始する前にプレースホルダに戻す
+    setBlobUrl(null);
     fetch(thumbnailLink, { headers: { Authorization: `Bearer ${accessToken}` } })
       .then((r) => (r.ok ? r.blob() : Promise.reject()))
       .then((blob) => {
@@ -280,47 +282,46 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
           )}
 
           {gpItems.length > 0 && (
-            <>
-              <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
-                {gpItems.map((item) => (
-                  <div
-                    key={item.id}
-                    className="relative group rounded overflow-hidden border border-gray-200 bg-gray-50 aspect-square"
-                  >
-                    <img
-                      src={PhotoImporter.getThumbnailUrl(item.baseUrl, 200, 200)}
-                      alt={item.filename}
-                      className="w-full h-full object-cover"
-                    />
-                    <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 flex flex-col items-center justify-center gap-1 transition-opacity">
-                      <p className="text-white text-xs text-center px-1 truncate w-full text-center">
-                        {item.filename}
-                      </p>
-                      <button
-                        onClick={() => importGooglePhoto(item)}
-                        disabled={importing === item.id}
-                        className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded transition-colors disabled:opacity-50"
-                      >
-                        {importing === item.id ? "取り込み中…" : "インポート"}
-                      </button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {gpNextPageToken && (
-                <button
-                  onClick={() => searchGooglePhotos(true)}
-                  disabled={gpLoading}
-                  className="self-center px-4 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 transition-colors disabled:opacity-50"
+            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+              {gpItems.map((item) => (
+                <div
+                  key={item.id}
+                  className="relative group rounded overflow-hidden border border-gray-200 bg-gray-50 aspect-square"
                 >
-                  {gpLoading ? "読み込み中…" : "さらに読み込む"}
-                </button>
-              )}
-            </>
+                  <img
+                    src={PhotoImporter.getThumbnailUrl(item.baseUrl, 200, 200)}
+                    alt={item.filename}
+                    className="w-full h-full object-cover"
+                  />
+                  <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 flex flex-col items-center justify-center gap-1 transition-opacity">
+                    <p className="text-white text-xs text-center px-1 truncate w-full text-center">
+                      {item.filename}
+                    </p>
+                    <button
+                      onClick={() => importGooglePhoto(item)}
+                      disabled={importing === item.id}
+                      className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded transition-colors disabled:opacity-50"
+                    >
+                      {importing === item.id ? "取り込み中…" : "インポート"}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
           )}
 
-          {!gpLoading && gpItems.length === 0 && (
+          {/* nextPageToken がある限りページングボタンを表示（キーワードフィルタでヒット0でも続きがある場合がある） */}
+          {gpNextPageToken && (
+            <button
+              onClick={() => searchGooglePhotos(true)}
+              disabled={gpLoading}
+              className="self-center px-4 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 transition-colors disabled:opacity-50"
+            >
+              {gpLoading ? "読み込み中…" : "さらに読み込む"}
+            </button>
+          )}
+
+          {!gpLoading && gpItems.length === 0 && !gpNextPageToken && (
             <p className="text-gray-400 text-sm text-center py-6">
               日付範囲やキーワードを指定して検索してください。
             </p>

--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -80,6 +80,11 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
     }
     return importerRef.current.importer;
   }, [accessToken]);
+
+  // タブ切り替えや新規検索で古いレスポンスを無視するための世代カウンタ
+  const gpSearchGenRef = useRef(0);
+  const drSearchGenRef = useRef(0);
+
   const [gpStartDate, setGpStartDate] = useState("");
   const [gpEndDate, setGpEndDate] = useState("");
   const [gpKeyword, setGpKeyword] = useState("");
@@ -108,6 +113,9 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
       const importer = getImporter();
       if (!importer) return;
 
+      // このリクエストの世代を記録し、resolve 時に最新かどうか確認する
+      const gen = ++gpSearchGenRef.current;
+
       setGpLoading(true);
       setGpError(null);
       try {
@@ -117,12 +125,14 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
           keyword: gpKeyword || undefined,
           pageToken: append ? gpNextPageToken : undefined,
         });
+        if (gen !== gpSearchGenRef.current) return; // タブ切り替え等で古い結果は破棄
         setGpItems((prev: GooglePhotosMediaItem[]) => (append ? [...prev, ...result.mediaItems] : result.mediaItems));
         setGpNextPageToken(result.nextPageToken);
       } catch (e) {
+        if (gen !== gpSearchGenRef.current) return;
         setGpError(e instanceof Error ? e.message : String(e));
       } finally {
-        setGpLoading(false);
+        if (gen === gpSearchGenRef.current) setGpLoading(false);
       }
     },
     [getImporter, gpStartDate, gpEndDate, gpKeyword, gpNextPageToken],
@@ -137,6 +147,8 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
       const importer = getImporter();
       if (!importer) return;
 
+      const gen = ++drSearchGenRef.current;
+
       setDrLoading(true);
       setDrError(null);
       try {
@@ -144,12 +156,14 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
           keyword: drKeyword || undefined,
           pageToken: append ? drNextPageToken : undefined,
         });
+        if (gen !== drSearchGenRef.current) return;
         setDrFiles((prev: DriveImageFile[]) => (append ? [...prev, ...result.files] : result.files));
         setDrNextPageToken(result.nextPageToken);
       } catch (e) {
+        if (gen !== drSearchGenRef.current) return;
         setDrError(e instanceof Error ? e.message : String(e));
       } finally {
-        setDrLoading(false);
+        if (gen === drSearchGenRef.current) setDrLoading(false);
       }
     },
     [getImporter, drKeyword, drNextPageToken],
@@ -193,8 +207,10 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
     [getImporter, onImported],
   );
 
-  // Tab 切り替え時にリセット
+  // Tab 切り替え時にリセット（世代カウンタを進めて in-flight リクエストの結果を破棄）
   useEffect(() => {
+    gpSearchGenRef.current++;
+    drSearchGenRef.current++;
     setGpItems([]);
     setGpNextPageToken(undefined);
     setGpError(null);

--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -43,6 +43,8 @@ function AuthedThumbnail({
     })
       .then((r) => (r.ok ? r.blob() : Promise.reject()))
       .then((blob) => {
+        // cleanup 後（abort 済み）に then() が走った場合は state 更新をスキップ
+        if (controller.signal.aborted) return;
         const url = URL.createObjectURL(blob);
         prevUrl.current = url;
         setBlobUrl(url);

--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -69,7 +69,17 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
   const { accessToken } = useAuth();
   const [tab, setTab] = useState<Tab>("google_photos");
 
-  // --- Google Photos state ---
+  // accessToken 単位で PhotoImporter インスタンスを再利用（index.json の load() を重複して呼ばない）
+  const importerRef = useRef<{ token: string; importer: PhotoImporter } | null>(null);
+  const getImporter = useCallback((): PhotoImporter | null => {
+    if (!accessToken) return null;
+    if (importerRef.current?.token !== accessToken) {
+      const client = createDriveClient(accessToken);
+      const indexManager = new IndexManager(client);
+      importerRef.current = { token: accessToken, importer: new PhotoImporter(client, indexManager, accessToken) };
+    }
+    return importerRef.current.importer;
+  }, [accessToken]);
   const [gpStartDate, setGpStartDate] = useState("");
   const [gpEndDate, setGpEndDate] = useState("");
   const [gpKeyword, setGpKeyword] = useState("");
@@ -88,12 +98,6 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
   // --- importing state ---
   const [importing, setImporting] = useState<string | null>(null);
 
-  const makeImporter = useCallback((): PhotoImporter | null => {
-    if (!accessToken) return null;
-    const client = createDriveClient(accessToken);
-    const indexManager = new IndexManager(client);
-    return new PhotoImporter(client, indexManager, accessToken);
-  }, [accessToken]);
 
   // ------------------------------------------------------------------
   // Google Photos 検索
@@ -101,7 +105,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
 
   const searchGooglePhotos = useCallback(
     async (append = false) => {
-      const importer = makeImporter();
+      const importer = getImporter();
       if (!importer) return;
 
       setGpLoading(true);
@@ -121,7 +125,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
         setGpLoading(false);
       }
     },
-    [makeImporter, gpStartDate, gpEndDate, gpKeyword, gpNextPageToken],
+    [getImporter, gpStartDate, gpEndDate, gpKeyword, gpNextPageToken],
   );
 
   // ------------------------------------------------------------------
@@ -130,7 +134,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
 
   const searchDriveImages = useCallback(
     async (append = false) => {
-      const importer = makeImporter();
+      const importer = getImporter();
       if (!importer) return;
 
       setDrLoading(true);
@@ -148,7 +152,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
         setDrLoading(false);
       }
     },
-    [makeImporter, drKeyword, drNextPageToken],
+    [getImporter, drKeyword, drNextPageToken],
   );
 
   // ------------------------------------------------------------------
@@ -157,12 +161,10 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
 
   const importGooglePhoto = useCallback(
     async (item: GooglePhotosMediaItem) => {
-      if (!accessToken) return;
+      const importer = getImporter();
+      if (!importer) return;
       setImporting(item.id);
       try {
-        const client = createDriveClient(accessToken);
-        const indexManager = new IndexManager(client);
-        const importer = new PhotoImporter(client, indexManager, accessToken);
         const photo = await importer.importFromGooglePhotos(item);
         onImported?.(photo);
       } catch (e) {
@@ -171,17 +173,15 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
         setImporting(null);
       }
     },
-    [accessToken, onImported],
+    [getImporter, onImported],
   );
 
   const importDriveFile = useCallback(
     async (file: DriveImageFile) => {
-      if (!accessToken) return;
+      const importer = getImporter();
+      if (!importer) return;
       setImporting(file.id);
       try {
-        const client = createDriveClient(accessToken);
-        const indexManager = new IndexManager(client);
-        const importer = new PhotoImporter(client, indexManager, accessToken);
         const photo = await importer.importFromGoogleDrive(file);
         onImported?.(photo);
       } catch (e) {
@@ -190,15 +190,19 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
         setImporting(null);
       }
     },
-    [accessToken, onImported],
+    [getImporter, onImported],
   );
 
   // Tab 切り替え時にリセット
   useEffect(() => {
     setGpItems([]);
     setGpNextPageToken(undefined);
+    setGpError(null);
+    setGpLoading(false);
     setDrFiles([]);
     setDrNextPageToken(undefined);
+    setDrError(null);
+    setDrLoading(false);
   }, [tab]);
 
   if (!accessToken) {

--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import {
   PhotoImporter,
-  type GooglePhotosMediaItem,
+  type PickerMediaItem,
   type DriveImageFile,
 } from "@/lib/photo-importer";
 import { createDriveClient } from "@/lib/drive-client";
@@ -35,7 +35,6 @@ function AuthedThumbnail({
 
   useEffect(() => {
     const controller = new AbortController();
-    // 新しい fetch を開始する前にプレースホルダに戻す
     setBlobUrl(null);
     fetch(thumbnailLink, {
       headers: { Authorization: `Bearer ${accessToken}` },
@@ -43,14 +42,12 @@ function AuthedThumbnail({
     })
       .then((r) => (r.ok ? r.blob() : Promise.reject()))
       .then((blob) => {
-        // cleanup 後（abort 済み）に then() が走った場合は state 更新をスキップ
         if (controller.signal.aborted) return;
         const url = URL.createObjectURL(blob);
         prevUrl.current = url;
         setBlobUrl(url);
       })
       .catch((err) => {
-        // AbortError は正常な中断なので無視
         if (err instanceof DOMException && err.name === "AbortError") return;
       });
     return () => {
@@ -76,7 +73,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
   const { accessToken } = useAuth();
   const [tab, setTab] = useState<Tab>("google_photos");
 
-  // accessToken 単位で PhotoImporter インスタンスを再利用（index.json の load() を重複して呼ばない）
+  // accessToken 単位で PhotoImporter インスタンスを再利用
   const importerRef = useRef<{ token: string; importer: PhotoImporter } | null>(null);
   const getImporter = useCallback((): PhotoImporter | null => {
     if (!accessToken) return null;
@@ -88,19 +85,17 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
     return importerRef.current.importer;
   }, [accessToken]);
 
-  // タブ切り替えや新規検索で古いレスポンスを無視するための世代カウンタ
-  const gpSearchGenRef = useRef(0);
-  const drSearchGenRef = useRef(0);
-
-  const [gpStartDate, setGpStartDate] = useState("");
-  const [gpEndDate, setGpEndDate] = useState("");
-  const [gpKeyword, setGpKeyword] = useState("");
-  const [gpItems, setGpItems] = useState<GooglePhotosMediaItem[]>([]);
+  // --- Google Photos Picker state ---
+  const [gpSession, setGpSession] = useState<{ id: string; pollIntervalMs: number } | null>(null);
+  const [gpPolling, setGpPolling] = useState(false);
+  const [gpItems, setGpItems] = useState<PickerMediaItem[]>([]);
   const [gpNextPageToken, setGpNextPageToken] = useState<string | undefined>();
   const [gpLoading, setGpLoading] = useState(false);
   const [gpError, setGpError] = useState<string | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // --- Google Drive state ---
+  const drSearchGenRef = useRef(0);
   const [drKeyword, setDrKeyword] = useState("");
   const [drFiles, setDrFiles] = useState<DriveImageFile[]>([]);
   const [drNextPageToken, setDrNextPageToken] = useState<string | undefined>();
@@ -110,40 +105,107 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
   // --- importing state ---
   const [importing, setImporting] = useState<string | null>(null);
 
-
   // ------------------------------------------------------------------
-  // Google Photos 検索
+  // Google Photos Picker フロー
   // ------------------------------------------------------------------
 
-  const searchGooglePhotos = useCallback(
-    async (append = false) => {
+  const stopPolling = useCallback(() => {
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+    setGpPolling(false);
+  }, []);
+
+  const cancelPickerSession = useCallback(async () => {
+    stopPolling();
+    if (gpSession) {
       const importer = getImporter();
-      if (!importer) return;
+      importer?.deletePickerSession(gpSession.id).catch(() => {});
+    }
+    setGpSession(null);
+    setGpItems([]);
+    setGpNextPageToken(undefined);
+    setGpError(null);
+  }, [gpSession, getImporter, stopPolling]);
 
-      // このリクエストの世代を記録し、resolve 時に最新かどうか確認する
-      const gen = ++gpSearchGenRef.current;
-
-      setGpLoading(true);
-      setGpError(null);
-      try {
-        const result = await importer.searchGooglePhotos({
-          startDate: gpStartDate || undefined,
-          endDate: gpEndDate || undefined,
-          keyword: gpKeyword || undefined,
-          pageToken: append ? gpNextPageToken : undefined,
-        });
-        if (gen !== gpSearchGenRef.current) return; // タブ切り替え等で古い結果は破棄
-        setGpItems((prev: GooglePhotosMediaItem[]) => (append ? [...prev, ...result.mediaItems] : result.mediaItems));
-        setGpNextPageToken(result.nextPageToken);
-      } catch (e) {
-        if (gen !== gpSearchGenRef.current) return;
-        setGpError(e instanceof Error ? e.message : String(e));
-      } finally {
-        if (gen === gpSearchGenRef.current) setGpLoading(false);
-      }
+  /** セッションをポーリングし、mediaItemsSet になったらアイテムを取得する。 */
+  const pollSession = useCallback(
+    (sessionId: string, intervalMs: number, importer: PhotoImporter) => {
+      const tick = async () => {
+        try {
+          const session = await importer.getPickerSession(sessionId);
+          if (session.mediaItemsSet) {
+            stopPolling();
+            setGpLoading(true);
+            try {
+              const result = await importer.listPickerMediaItems(sessionId);
+              setGpItems(result.mediaItems);
+              setGpNextPageToken(result.nextPageToken);
+            } catch (e) {
+              setGpError(e instanceof Error ? e.message : String(e));
+            } finally {
+              setGpLoading(false);
+            }
+          } else {
+            pollTimerRef.current = setTimeout(tick, intervalMs);
+          }
+        } catch (e) {
+          stopPolling();
+          setGpError(e instanceof Error ? e.message : String(e));
+        }
+      };
+      pollTimerRef.current = setTimeout(tick, intervalMs);
     },
-    [getImporter, gpStartDate, gpEndDate, gpKeyword, gpNextPageToken],
+    [stopPolling],
   );
+
+  const openGooglePhotosPicker = useCallback(async () => {
+    const importer = getImporter();
+    if (!importer) return;
+
+    setGpError(null);
+    setGpItems([]);
+    setGpNextPageToken(undefined);
+    setGpLoading(true);
+
+    try {
+      const session = await importer.createPickerSession();
+
+      // "5s" → 5000ms
+      const rawInterval = session.pollingConfig?.pollInterval ?? "5s";
+      const pollIntervalMs = (parseFloat(rawInterval) || 5) * 1000;
+
+      setGpSession({ id: session.id, pollIntervalMs });
+
+      // クリックハンドラ内でポップアップを開く（ポップアップブロッカー対策）
+      window.open(session.pickerUri, "_blank", "width=1000,height=700");
+
+      setGpPolling(true);
+      pollSession(session.id, pollIntervalMs, importer);
+    } catch (e) {
+      setGpError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setGpLoading(false);
+    }
+  }, [getImporter, pollSession]);
+
+  const loadMorePickerItems = useCallback(async () => {
+    if (!gpSession || !gpNextPageToken) return;
+    const importer = getImporter();
+    if (!importer) return;
+
+    setGpLoading(true);
+    try {
+      const result = await importer.listPickerMediaItems(gpSession.id, gpNextPageToken);
+      setGpItems((prev) => [...prev, ...result.mediaItems]);
+      setGpNextPageToken(result.nextPageToken);
+    } catch (e) {
+      setGpError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setGpLoading(false);
+    }
+  }, [gpSession, gpNextPageToken, getImporter]);
 
   // ------------------------------------------------------------------
   // Google Drive 検索
@@ -181,7 +243,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
   // ------------------------------------------------------------------
 
   const importGooglePhoto = useCallback(
-    async (item: GooglePhotosMediaItem) => {
+    async (item: PickerMediaItem) => {
       const importer = getImporter();
       if (!importer) return;
       setImporting(item.id);
@@ -214,24 +276,36 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
     [getImporter, onImported],
   );
 
-  // Tab 切り替え時にリセット（世代カウンタを進めて in-flight リクエストの結果を破棄）
+  // Tab 切り替え時にポーリングをリセット
   useEffect(() => {
-    gpSearchGenRef.current++;
-    drSearchGenRef.current++;
+    stopPolling();
+    if (gpSession) {
+      const importer = getImporter();
+      importer?.deletePickerSession(gpSession.id).catch(() => {});
+      setGpSession(null);
+    }
     setGpItems([]);
     setGpNextPageToken(undefined);
     setGpError(null);
-    setGpLoading(false);
     setDrFiles([]);
     setDrNextPageToken(undefined);
     setDrError(null);
     setDrLoading(false);
+    drSearchGenRef.current++;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab]);
+
+  // アンマウント時にポーリング停止
+  useEffect(() => {
+    return () => {
+      stopPolling();
+    };
+  }, [stopPolling]);
 
   if (!accessToken) {
     return (
       <div className="p-4 text-gray-500 text-sm">
-        写真を検索するにはログインが必要です。
+        写真を取り込むにはログインが必要です。
       </div>
     );
   }
@@ -265,93 +339,94 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
       {/* Google Photos パネル */}
       {tab === "google_photos" && (
         <div className="flex flex-col gap-3">
-          <div className="flex flex-wrap gap-2 items-end">
-            <label className="flex flex-col gap-1 text-xs text-gray-600">
-              開始日
-              <input
-                type="date"
-                value={gpStartDate}
-                onChange={(e) => setGpStartDate(e.target.value)}
-                className="border border-gray-300 rounded px-2 py-1 text-sm"
-              />
-            </label>
-            <label className="flex flex-col gap-1 text-xs text-gray-600">
-              終了日
-              <input
-                type="date"
-                value={gpEndDate}
-                onChange={(e) => setGpEndDate(e.target.value)}
-                className="border border-gray-300 rounded px-2 py-1 text-sm"
-              />
-            </label>
-            <label className="flex flex-col gap-1 text-xs text-gray-600 flex-1 min-w-32">
-              キーワード（ファイル名）
-              <input
-                type="text"
-                value={gpKeyword}
-                onChange={(e) => setGpKeyword(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && searchGooglePhotos(false)}
-                placeholder="部分一致"
-                className="border border-gray-300 rounded px-2 py-1 text-sm"
-              />
-            </label>
-            <button
-              onClick={() => searchGooglePhotos(false)}
-              disabled={gpLoading}
-              className="px-3 py-1.5 bg-blue-500 hover:bg-blue-600 text-white text-sm rounded transition-colors disabled:opacity-50"
-            >
-              {gpLoading ? "検索中…" : "検索"}
-            </button>
-          </div>
-
-          {gpError && (
-            <p className="text-red-500 text-sm">{gpError}</p>
-          )}
-
-          {gpItems.length > 0 && (
-            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
-              {gpItems.map((item) => (
-                <div
-                  key={item.id}
-                  className="relative group rounded overflow-hidden border border-gray-200 bg-gray-50 aspect-square"
-                >
-                  <img
-                    src={PhotoImporter.getThumbnailUrl(item.baseUrl, 200, 200)}
-                    alt={item.filename}
-                    className="w-full h-full object-cover"
-                  />
-                  <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 flex flex-col items-center justify-center gap-1 transition-opacity">
-                    <p className="text-white text-xs text-center px-1 truncate w-full text-center">
-                      {item.filename}
-                    </p>
-                    <button
-                      onClick={() => importGooglePhoto(item)}
-                      disabled={importing === item.id}
-                      className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded transition-colors disabled:opacity-50"
-                    >
-                      {importing === item.id ? "取り込み中…" : "インポート"}
-                    </button>
-                  </div>
-                </div>
-              ))}
+          {!gpSession && !gpPolling && gpItems.length === 0 && (
+            <div className="flex flex-col items-center gap-4 py-10">
+              <p className="text-sm text-gray-500 text-center max-w-sm">
+                Google Photos のピッカーを開いて写真を選択してください。選択後、自動的にここに表示されます。
+              </p>
+              <button
+                onClick={openGooglePhotosPicker}
+                disabled={gpLoading}
+                className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white text-sm rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+              >
+                {gpLoading ? "準備中…" : "Google Photos を開く"}
+              </button>
             </div>
           )}
 
-          {/* nextPageToken がある限りページングボタンを表示（キーワードフィルタでヒット0でも続きがある場合がある） */}
-          {gpNextPageToken && (
-            <button
-              onClick={() => searchGooglePhotos(true)}
-              disabled={gpLoading}
-              className="self-center px-4 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 transition-colors disabled:opacity-50"
-            >
-              {gpLoading ? "読み込み中…" : "さらに読み込む"}
-            </button>
+          {gpPolling && (
+            <div className="flex flex-col items-center gap-3 py-10">
+              <div className="w-8 h-8 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+              <p className="text-sm text-gray-600">Google Photos で写真を選択してください…</p>
+              <button
+                onClick={cancelPickerSession}
+                className="text-xs text-gray-400 hover:text-gray-600 underline"
+              >
+                キャンセル
+              </button>
+            </div>
           )}
 
-          {!gpLoading && gpItems.length === 0 && !gpNextPageToken && (
-            <p className="text-gray-400 text-sm text-center py-6">
-              日付範囲やキーワードを指定して検索してください。
-            </p>
+          {gpError && (
+            <div className="flex flex-col gap-2">
+              <p className="text-red-500 text-sm">{gpError}</p>
+              <button
+                onClick={() => { setGpError(null); setGpSession(null); }}
+                className="self-start text-xs text-blue-500 hover:underline"
+              >
+                再試行
+              </button>
+            </div>
+          )}
+
+          {gpItems.length > 0 && (
+            <>
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-gray-600">{gpItems.length} 件選択済み</p>
+                <button
+                  onClick={cancelPickerSession}
+                  className="text-xs text-gray-400 hover:text-gray-600 underline"
+                >
+                  クリア
+                </button>
+              </div>
+              <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+                {gpItems.map((item) => (
+                  <div
+                    key={item.id}
+                    className="relative group rounded overflow-hidden border border-gray-200 bg-gray-50 aspect-square"
+                  >
+                    <img
+                      src={PhotoImporter.getThumbnailUrl(item.mediaFile.baseUrl, 200, 200)}
+                      alt={item.mediaFile.filename}
+                      className="w-full h-full object-cover"
+                    />
+                    <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 flex flex-col items-center justify-center gap-1 transition-opacity">
+                      <p className="text-white text-xs text-center px-1 truncate w-full">
+                        {item.mediaFile.filename}
+                      </p>
+                      <button
+                        onClick={() => importGooglePhoto(item)}
+                        disabled={importing === item.id}
+                        className="px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded transition-colors disabled:opacity-50"
+                      >
+                        {importing === item.id ? "取り込み中…" : "インポート"}
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {gpNextPageToken && (
+                <button
+                  onClick={loadMorePickerItems}
+                  disabled={gpLoading}
+                  className="self-center px-4 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 transition-colors disabled:opacity-50"
+                >
+                  {gpLoading ? "読み込み中…" : "さらに読み込む"}
+                </button>
+              )}
+            </>
           )}
         </div>
       )}

--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -34,20 +34,25 @@ function AuthedThumbnail({
   const prevUrl = useRef<string | null>(null);
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     // 新しい fetch を開始する前にプレースホルダに戻す
     setBlobUrl(null);
-    fetch(thumbnailLink, { headers: { Authorization: `Bearer ${accessToken}` } })
+    fetch(thumbnailLink, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: controller.signal,
+    })
       .then((r) => (r.ok ? r.blob() : Promise.reject()))
       .then((blob) => {
-        if (cancelled) return;
         const url = URL.createObjectURL(blob);
         prevUrl.current = url;
         setBlobUrl(url);
       })
-      .catch(() => {});
+      .catch((err) => {
+        // AbortError は正常な中断なので無視
+        if (err instanceof DOMException && err.name === "AbortError") return;
+      });
     return () => {
-      cancelled = true;
+      controller.abort();
       if (prevUrl.current) {
         URL.revokeObjectURL(prevUrl.current);
         prevUrl.current = null;

--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -396,8 +396,9 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
                     key={item.id}
                     className="relative group rounded overflow-hidden border border-gray-200 bg-gray-50 aspect-square"
                   >
-                    <img
-                      src={PhotoImporter.getThumbnailUrl(item.mediaFile.baseUrl, 200, 200)}
+                    <AuthedThumbnail
+                      thumbnailLink={PhotoImporter.getThumbnailUrl(item.mediaFile.baseUrl, 200, 200)}
+                      accessToken={accessToken}
                       alt={item.mediaFile.filename}
                       className="w-full h-full object-cover"
                     />

--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import {
   PhotoImporter,
   type GooglePhotosMediaItem,
@@ -18,6 +18,51 @@ type PhotoPickerProps = {
   onImported?: (photo: PhotoObject) => void;
 };
 
+/** Drive thumbnailLink を Bearer トークン付きで fetch して Blob URL を返すコンポーネント。 */
+function AuthedThumbnail({
+  thumbnailLink,
+  accessToken,
+  alt,
+  className,
+}: {
+  thumbnailLink: string;
+  accessToken: string;
+  alt: string;
+  className?: string;
+}) {
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const prevUrl = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(thumbnailLink, { headers: { Authorization: `Bearer ${accessToken}` } })
+      .then((r) => (r.ok ? r.blob() : Promise.reject()))
+      .then((blob) => {
+        if (cancelled) return;
+        const url = URL.createObjectURL(blob);
+        prevUrl.current = url;
+        setBlobUrl(url);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      if (prevUrl.current) {
+        URL.revokeObjectURL(prevUrl.current);
+        prevUrl.current = null;
+      }
+    };
+  }, [thumbnailLink, accessToken]);
+
+  if (!blobUrl) {
+    return (
+      <div className={`bg-gray-100 flex items-center justify-center text-gray-400 text-xs ${className ?? ""}`}>
+        IMG
+      </div>
+    );
+  }
+  return <img src={blobUrl} alt={alt} className={className} />;
+}
+
 export function PhotoPicker({ onImported }: PhotoPickerProps) {
   const { accessToken } = useAuth();
   const [tab, setTab] = useState<Tab>("google_photos");
@@ -25,6 +70,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
   // --- Google Photos state ---
   const [gpStartDate, setGpStartDate] = useState("");
   const [gpEndDate, setGpEndDate] = useState("");
+  const [gpKeyword, setGpKeyword] = useState("");
   const [gpItems, setGpItems] = useState<GooglePhotosMediaItem[]>([]);
   const [gpNextPageToken, setGpNextPageToken] = useState<string | undefined>();
   const [gpLoading, setGpLoading] = useState(false);
@@ -62,6 +108,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
         const result = await importer.searchGooglePhotos({
           startDate: gpStartDate || undefined,
           endDate: gpEndDate || undefined,
+          keyword: gpKeyword || undefined,
           pageToken: append ? gpNextPageToken : undefined,
         });
         setGpItems((prev: GooglePhotosMediaItem[]) => (append ? [...prev, ...result.mediaItems] : result.mediaItems));
@@ -72,7 +119,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
         setGpLoading(false);
       }
     },
-    [makeImporter, gpStartDate, gpEndDate, gpNextPageToken],
+    [makeImporter, gpStartDate, gpEndDate, gpKeyword, gpNextPageToken],
   );
 
   // ------------------------------------------------------------------
@@ -108,16 +155,13 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
 
   const importGooglePhoto = useCallback(
     async (item: GooglePhotosMediaItem) => {
-      const importer = makeImporter();
-      if (!importer) return;
+      if (!accessToken) return;
       setImporting(item.id);
       try {
-        // IndexManager を load() してから使う
-        const client = createDriveClient(accessToken!);
+        const client = createDriveClient(accessToken);
         const indexManager = new IndexManager(client);
-        await indexManager.load();
-        const fullImporter = new PhotoImporter(client, indexManager, accessToken!);
-        const photo = await fullImporter.importFromGooglePhotos(item);
+        const importer = new PhotoImporter(client, indexManager, accessToken);
+        const photo = await importer.importFromGooglePhotos(item);
         onImported?.(photo);
       } catch (e) {
         alert(`インポートに失敗しました: ${e instanceof Error ? e.message : String(e)}`);
@@ -125,20 +169,18 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
         setImporting(null);
       }
     },
-    [makeImporter, accessToken, onImported],
+    [accessToken, onImported],
   );
 
   const importDriveFile = useCallback(
     async (file: DriveImageFile) => {
-      const importer = makeImporter();
-      if (!importer) return;
+      if (!accessToken) return;
       setImporting(file.id);
       try {
-        const client = createDriveClient(accessToken!);
+        const client = createDriveClient(accessToken);
         const indexManager = new IndexManager(client);
-        await indexManager.load();
-        const fullImporter = new PhotoImporter(client, indexManager, accessToken!);
-        const photo = await fullImporter.importFromGoogleDrive(file);
+        const importer = new PhotoImporter(client, indexManager, accessToken);
+        const photo = await importer.importFromGoogleDrive(file);
         onImported?.(photo);
       } catch (e) {
         alert(`インポートに失敗しました: ${e instanceof Error ? e.message : String(e)}`);
@@ -146,7 +188,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
         setImporting(null);
       }
     },
-    [makeImporter, accessToken, onImported],
+    [accessToken, onImported],
   );
 
   // Tab 切り替え時にリセット
@@ -213,6 +255,17 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
                 className="border border-gray-300 rounded px-2 py-1 text-sm"
               />
             </label>
+            <label className="flex flex-col gap-1 text-xs text-gray-600 flex-1 min-w-32">
+              キーワード（ファイル名）
+              <input
+                type="text"
+                value={gpKeyword}
+                onChange={(e) => setGpKeyword(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && searchGooglePhotos(false)}
+                placeholder="部分一致"
+                className="border border-gray-300 rounded px-2 py-1 text-sm"
+              />
+            </label>
             <button
               onClick={() => searchGooglePhotos(false)}
               disabled={gpLoading}
@@ -269,7 +322,7 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
 
           {!gpLoading && gpItems.length === 0 && (
             <p className="text-gray-400 text-sm text-center py-6">
-              日付範囲を指定して検索してください。
+              日付範囲やキーワードを指定して検索してください。
             </p>
           )}
         </div>
@@ -278,6 +331,9 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
       {/* Google Drive パネル */}
       {tab === "google_drive" && (
         <div className="flex flex-col gap-3">
+          <p className="text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+            Drive 検索には <code>drive.metadata.readonly</code> スコープが必要です。ログイン時に同意していない場合は再ログインしてください。
+          </p>
           <div className="flex gap-2 items-end">
             <label className="flex flex-col gap-1 text-xs text-gray-600 flex-1">
               ファイル名で検索
@@ -312,8 +368,9 @@ export function PhotoPicker({ onImported }: PhotoPickerProps) {
                     className="flex items-center gap-3 px-3 py-2 rounded border border-gray-200 hover:bg-gray-50"
                   >
                     {file.thumbnailLink ? (
-                      <img
-                        src={file.thumbnailLink}
+                      <AuthedThumbnail
+                        thumbnailLink={file.thumbnailLink}
+                        accessToken={accessToken}
                         alt={file.name}
                         className="w-10 h-10 object-cover rounded flex-shrink-0"
                       />

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -186,7 +186,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       "https://www.googleapis.com/auth/drive.file",
       "https://www.googleapis.com/auth/drive.appdata",
       "https://www.googleapis.com/auth/drive.metadata.readonly",
-      "https://www.googleapis.com/auth/photoslibrary.readonly",
+      "https://www.googleapis.com/auth/photospicker.mediaitems.readonly",
     ].join(" "),
   });
 

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -179,8 +179,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     },
     onError: clearAuth,
-    scope:
-      "openid email profile https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.metadata.readonly https://www.googleapis.com/auth/photoslibrary.readonly",
+    scope: [
+      "openid",
+      "email",
+      "profile",
+      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/drive.appdata",
+      "https://www.googleapis.com/auth/drive.metadata.readonly",
+      "https://www.googleapis.com/auth/photoslibrary.readonly",
+    ].join(" "),
   });
 
   const logout = useCallback(() => {

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -180,7 +180,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     },
     onError: clearAuth,
     scope:
-      "openid email profile https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/photoslibrary.readonly",
+      "openid email profile https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive.metadata.readonly https://www.googleapis.com/auth/photoslibrary.readonly",
   });
 
   const logout = useCallback(() => {

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -180,7 +180,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     },
     onError: clearAuth,
     scope:
-      "openid email profile https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.appdata",
+      "openid email profile https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/photoslibrary.readonly",
   });
 
   const logout = useCallback(() => {

--- a/src/lib/photo-importer.ts
+++ b/src/lib/photo-importer.ts
@@ -31,6 +31,12 @@ function parseIsoDateToYMD(iso: string): { year: number; month: number; day: num
       month < 1 || month > 12 || day < 1 || day > 31) {
     throw new Error(`Invalid date value: "${iso}".`);
   }
+  // Date.UTC で実在日付かどうかを検証（例: 2026-02-31 は 3 月に繰り越される）
+  const utc = Date.UTC(year, month - 1, day);
+  const d = new Date(utc);
+  if (d.getUTCFullYear() !== year || d.getUTCMonth() + 1 !== month || d.getUTCDate() !== day) {
+    throw new Error(`Date does not exist: "${iso}".`);
+  }
   return { year, month, day };
 }
 
@@ -210,9 +216,14 @@ export class PhotoImporter {
       "nextPageToken,files(id,name,mimeType,thumbnailLink,createdTime,modifiedTime)",
     );
 
+    // Drive API の pageSize は 1..1000 の範囲に制限
+    const clampedPageSize = Number.isFinite(pageSize)
+      ? Math.min(1000, Math.max(1, pageSize))
+      : 50;
+
     const url =
       `https://www.googleapis.com/drive/v3/files?q=${query}&spaces=drive` +
-      `&fields=${fields}&pageSize=${pageSize}&orderBy=createdTime+desc${pageParam}`;
+      `&fields=${fields}&pageSize=${clampedPageSize}&orderBy=createdTime+desc${pageParam}`;
 
     const res = await fetch(url, {
       headers: {

--- a/src/lib/photo-importer.ts
+++ b/src/lib/photo-importer.ts
@@ -18,10 +18,19 @@ function escapeDriveQueryValue(value: string): string {
 /**
  * ISO 8601 の日付文字列（YYYY-MM-DD または YYYY-MM-DDTHH:mm:ssZ）を
  * タイムゾーン非依存で year/month/day オブジェクトに変換する。
+ * 形式が不正な場合はエラーをスローする。
  */
 function parseIsoDateToYMD(iso: string): { year: number; month: number; day: number } {
   const datePart = iso.split("T")[0];
-  const [year, month, day] = datePart.split("-").map(Number);
+  const parts = datePart.split("-");
+  if (parts.length !== 3) {
+    throw new Error(`Invalid date format: "${iso}". Expected YYYY-MM-DD.`);
+  }
+  const [year, month, day] = parts.map(Number);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day) ||
+      month < 1 || month > 12 || day < 1 || day > 31) {
+    throw new Error(`Invalid date value: "${iso}".`);
+  }
   return { year, month, day };
 }
 

--- a/src/lib/photo-importer.ts
+++ b/src/lib/photo-importer.ts
@@ -119,13 +119,12 @@ export class PhotoImporter {
     };
 
     if (startDate || endDate) {
+      // Google Photos の dateFilter.ranges は startDate/endDate の両方が必須。
+      // 片方のみ指定の場合は同じ日付を補完する。
+      const start = parseIsoDateToYMD(startDate ?? endDate!);
+      const end = parseIsoDateToYMD(endDate ?? startDate!);
       filters.dateFilter = {
-        ranges: [
-          {
-            ...(startDate ? { startDate: parseIsoDateToYMD(startDate) } : {}),
-            ...(endDate ? { endDate: parseIsoDateToYMD(endDate) } : {}),
-          },
-        ],
+        ranges: [{ startDate: start, endDate: end }],
       };
     }
 
@@ -313,15 +312,16 @@ export class PhotoImporter {
   }
 
   /**
-   * Drive の thumbnailLink を Authorization ヘッダ付きで取得し Blob URL を返す。
+   * Drive の thumbnailLink を Authorization ヘッダ付きで取得して Blob を返す。
    * Drive サムネイルはサードパーティ Cookie 制限下で img src に直接使えないことがあるため。
+   * Blob URL が必要な場合は呼び出し側で URL.createObjectURL() し、
+   * 不要になったら URL.revokeObjectURL() を呼んでください。
    */
-  async fetchDriveThumbnailBlobUrl(thumbnailLink: string): Promise<string> {
+  async fetchDriveThumbnailBlob(thumbnailLink: string): Promise<Blob> {
     const res = await fetch(thumbnailLink, {
       headers: { Authorization: `Bearer ${this.accessToken}` },
     });
     if (!res.ok) throw new Error(`thumbnail fetch failed: ${res.status}`);
-    const blob = await res.blob();
-    return URL.createObjectURL(blob);
+    return res.blob();
   }
 }

--- a/src/lib/photo-importer.ts
+++ b/src/lib/photo-importer.ts
@@ -129,9 +129,15 @@ export class PhotoImporter {
 
     if (startDate || endDate) {
       // Google Photos の dateFilter.ranges は startDate/endDate の両方が必須。
-      // 片方のみ指定の場合は同じ日付を補完する。
-      const start = parseIsoDateToYMD(startDate ?? endDate!);
-      const end = parseIsoDateToYMD(endDate ?? startDate!);
+      // 片方のみ指定の場合は同じ日付を補完する。start > end の場合は入れ替えて正規化。
+      let start = parseIsoDateToYMD(startDate ?? endDate!);
+      let end = parseIsoDateToYMD(endDate ?? startDate!);
+      // 年月日を比較して start <= end になるよう正規化
+      const startTs = start.year * 10000 + start.month * 100 + start.day;
+      const endTs = end.year * 10000 + end.month * 100 + end.day;
+      if (startTs > endTs) {
+        [start, end] = [end, start];
+      }
       filters.dateFilter = {
         ranges: [{ startDate: start, endDate: end }],
       };

--- a/src/lib/photo-importer.ts
+++ b/src/lib/photo-importer.ts
@@ -15,61 +15,51 @@ function escapeDriveQueryValue(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 }
 
-/**
- * ISO 8601 の日付文字列（YYYY-MM-DD または YYYY-MM-DDTHH:mm:ssZ）を
- * タイムゾーン非依存で year/month/day オブジェクトに変換する。
- * 形式が不正な場合はエラーをスローする。
- */
-function parseIsoDateToYMD(iso: string): { year: number; month: number; day: number } {
-  const datePart = iso.split("T")[0];
-  const parts = datePart.split("-");
-  if (parts.length !== 3) {
-    throw new Error(`日付の形式が正しくありません: "${iso}"（YYYY-MM-DD 形式で入力してください）。`);
-  }
-  const [year, month, day] = parts.map(Number);
-  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day) ||
-      month < 1 || month > 12 || day < 1 || day > 31) {
-    throw new Error(`日付の値が不正です: "${iso}"（月は 1〜12、日は 1〜31 の範囲で指定してください）。`);
-  }
-  // Date.UTC で実在日付かどうかを検証（例: 2026-02-31 は 3 月に繰り越される）
-  const utc = Date.UTC(year, month - 1, day);
-  const d = new Date(utc);
-  if (d.getUTCFullYear() !== year || d.getUTCMonth() + 1 !== month || d.getUTCDate() !== day) {
-    throw new Error(`存在しない日付です: "${iso}"（${month} 月に ${day} 日はありません）。`);
-  }
-  return { year, month, day };
-}
+// ------------------------------------------------------------------
+// Google Photos Picker API 型定義
+// ------------------------------------------------------------------
 
-/** Google Photos API のメディアアイテム（必要フィールドのみ）。 */
-export type GooglePhotosMediaItem = {
+/** Picker API セッション。 */
+export type PickerSession = {
   id: string;
-  filename: string;
-  mediaMetadata: {
-    creationTime?: string;
-    width?: string;
-    height?: string;
-    photo?: Record<string, unknown>;
+  pickerUri: string;
+  pollingConfig: {
+    /** ポーリング間隔（例: "5s"）。 */
+    pollInterval: string;
+    /** タイムアウト（例: "300s"）。 */
+    timeoutIn: string;
   };
-  baseUrl: string;
+  /** ユーザーが写真の選択を完了したら true になる。 */
+  mediaItemsSet?: boolean;
+  expireTime?: string;
 };
 
-/** Google Photos 検索オプション。 */
-export type GooglePhotosSearchOptions = {
-  /** 絞り込む開始日（YYYY-MM-DD または ISO 8601 形式）。 */
-  startDate?: string;
-  /** 絞り込む終了日（YYYY-MM-DD または ISO 8601 形式）。 */
-  endDate?: string;
-  /** ファイル名部分一致フィルタ（クライアントサイドで適用）。 */
-  keyword?: string;
-  /** 1ページあたりの件数（最大 100）。 */
-  pageSize?: number;
-  pageToken?: string;
+/** Picker API メディアアイテム。 */
+export type PickerMediaItem = {
+  id: string;
+  createTime?: string;
+  type?: string;
+  mediaFile: {
+    baseUrl: string;
+    mimeType: string;
+    filename: string;
+    mediaFileMetadata?: {
+      width?: number;
+      height?: number;
+      photoMetadata?: Record<string, unknown>;
+      videoMetadata?: Record<string, unknown>;
+    };
+  };
 };
 
-export type GooglePhotosSearchResult = {
-  mediaItems: GooglePhotosMediaItem[];
+export type PickerMediaItemsResult = {
+  mediaItems: PickerMediaItem[];
   nextPageToken?: string;
 };
+
+// ------------------------------------------------------------------
+// Google Drive 画像検索型定義
+// ------------------------------------------------------------------
 
 /** Google Drive の画像ファイル検索結果。 */
 export type DriveImageFile = {
@@ -86,10 +76,10 @@ export type DriveImageSearchResult = {
   nextPageToken?: string;
 };
 
-const PHOTOS_API_BASE = "https://photoslibrary.googleapis.com/v1";
+const PICKER_API_BASE = "https://photospicker.googleapis.com/v1";
 
 /**
- * Google Photos / Google Drive から写真を検索し、
+ * Google Photos Picker API / Google Drive から写真を検索し、
  * PhotoObject として appDataFolder に保存するクラス。
  *
  * IndexManager は初回操作時に自動で load() される。
@@ -123,74 +113,66 @@ export class PhotoImporter {
   }
 
   // ------------------------------------------------------------------
-  // Google Photos 検索
+  // Google Photos Picker API
   // ------------------------------------------------------------------
 
-  /** Google Photos からメディアアイテムを検索する。 */
-  async searchGooglePhotos(
-    options: GooglePhotosSearchOptions = {},
-  ): Promise<GooglePhotosSearchResult> {
-    const { startDate, endDate, keyword, pageSize = 50, pageToken } = options;
-
-    const filters: Record<string, unknown> = {
-      // 動画を除外して写真のみ返す
-      mediaTypeFilter: { mediaTypes: ["PHOTO"] },
-    };
-
-    if (startDate || endDate) {
-      // Google Photos の dateFilter.ranges は startDate/endDate の両方が必須。
-      // 片方のみ指定の場合は同じ日付を補完する。start > end の場合は入れ替えて正規化。
-      let start = parseIsoDateToYMD(startDate ?? endDate!);
-      let end = parseIsoDateToYMD(endDate ?? startDate!);
-      // 年月日を比較して start <= end になるよう正規化
-      const startTs = start.year * 10000 + start.month * 100 + start.day;
-      const endTs = end.year * 10000 + end.month * 100 + end.day;
-      if (startTs > endTs) {
-        [start, end] = [end, start];
-      }
-      filters.dateFilter = {
-        ranges: [{ startDate: start, endDate: end }],
-      };
-    }
-
-    const body: Record<string, unknown> = {
-      // Google Photos API の pageSize は 1..100 の範囲に制限
-      pageSize: Math.min(100, Math.max(1, pageSize)),
-      filters,
-    };
-    if (pageToken) body.pageToken = pageToken;
-
-    const res = await fetch(`${PHOTOS_API_BASE}/mediaItems:search`, {
+  /** Picker セッションを作成する。 */
+  async createPickerSession(): Promise<PickerSession> {
+    const res = await fetch(`${PICKER_API_BASE}/sessions`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${this.accessToken}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(body),
+      body: JSON.stringify({}),
     });
-
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(
-        `Google Photos API error ${res.status}: ${JSON.stringify(err)}`,
-      );
+      throw new Error(`Picker API error ${res.status}: ${JSON.stringify(err)}`);
     }
+    return res.json() as Promise<PickerSession>;
+  }
 
+  /** Picker セッションの状態を取得する（ポーリング用）。 */
+  async getPickerSession(sessionId: string): Promise<PickerSession> {
+    const res = await fetch(`${PICKER_API_BASE}/sessions/${encodeURIComponent(sessionId)}`, {
+      headers: { Authorization: `Bearer ${this.accessToken}` },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(`Picker API error ${res.status}: ${JSON.stringify(err)}`);
+    }
+    return res.json() as Promise<PickerSession>;
+  }
+
+  /** Picker セッションで選択されたメディアアイテムを取得する。 */
+  async listPickerMediaItems(
+    sessionId: string,
+    pageToken?: string,
+  ): Promise<PickerMediaItemsResult> {
+    const params = new URLSearchParams({ sessionId });
+    if (pageToken) params.set("pageToken", pageToken);
+
+    const res = await fetch(`${PICKER_API_BASE}/mediaItems?${params}`, {
+      headers: { Authorization: `Bearer ${this.accessToken}` },
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(`Picker API error ${res.status}: ${JSON.stringify(err)}`);
+    }
     const data = await res.json();
-    let mediaItems: GooglePhotosMediaItem[] = data.mediaItems ?? [];
-
-    // Google Photos API にファイル名検索がないため、クライアント側でフィルタする
-    if (keyword) {
-      const lower = keyword.toLowerCase();
-      mediaItems = mediaItems.filter((item) =>
-        item.filename.toLowerCase().includes(lower),
-      );
-    }
-
     return {
-      mediaItems,
+      mediaItems: data.mediaItems ?? [],
       nextPageToken: data.nextPageToken,
     };
+  }
+
+  /** Picker セッションを削除する。 */
+  async deletePickerSession(sessionId: string): Promise<void> {
+    await fetch(`${PICKER_API_BASE}/sessions/${encodeURIComponent(sessionId)}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${this.accessToken}` },
+    });
   }
 
   // ------------------------------------------------------------------
@@ -254,9 +236,9 @@ export class PhotoImporter {
   // 写真インポート
   // ------------------------------------------------------------------
 
-  /** Google Photos のメディアアイテムを PhotoObject として保存する。 */
+  /** Google Photos Picker のメディアアイテムを PhotoObject として保存する。 */
   async importFromGooglePhotos(
-    item: GooglePhotosMediaItem,
+    item: PickerMediaItem,
   ): Promise<PhotoObject> {
     await this.ensureIndexLoaded();
 
@@ -268,8 +250,8 @@ export class PhotoImporter {
       importedAt,
       sourceType: "google_photos" as PhotoSourceType,
       sourceRef: item.id,
-      title: item.filename,
-      takenAt: item.mediaMetadata.creationTime,
+      title: item.mediaFile.filename,
+      takenAt: item.createTime,
     };
 
     const created = await this.client.createAppDataFile(photoFileName(id), photo);
@@ -342,7 +324,7 @@ export class PhotoImporter {
   }
 
   /**
-   * Google Photos のベース URL からサムネイル URL を生成する。
+   * Google Photos Picker の baseUrl からサムネイル URL を生成する。
    * baseUrl に `=w<width>-h<height>` を付与するとリサイズされた画像が得られる。
    */
   static getThumbnailUrl(

--- a/src/lib/photo-importer.ts
+++ b/src/lib/photo-importer.ts
@@ -138,7 +138,8 @@ export class PhotoImporter {
     }
 
     const body: Record<string, unknown> = {
-      pageSize,
+      // Google Photos API の pageSize は 1..100 の範囲に制限
+      pageSize: Math.min(100, Math.max(1, pageSize)),
       filters,
     };
     if (pageToken) body.pageToken = pageToken;
@@ -250,8 +251,14 @@ export class PhotoImporter {
       takenAt: item.mediaMetadata.creationTime,
     };
 
-    await this.client.createAppDataFile(photoFileName(id), photo);
-    await this.indexManager.addPhoto({ id, importedAt, sourceType: "google_photos" });
+    const created = await this.client.createAppDataFile(photoFileName(id), photo);
+    try {
+      await this.indexManager.addPhoto({ id, importedAt, sourceType: "google_photos" });
+    } catch (err) {
+      // index 登録に失敗した場合、作成済みファイルをロールバック削除する
+      await this.client.deleteFile(created.id).catch(() => {});
+      throw err;
+    }
 
     return photo;
   }
@@ -272,8 +279,13 @@ export class PhotoImporter {
       takenAt: file.createdTime,
     };
 
-    await this.client.createAppDataFile(photoFileName(id), photo);
-    await this.indexManager.addPhoto({ id, importedAt, sourceType: "google_drive" });
+    const created = await this.client.createAppDataFile(photoFileName(id), photo);
+    try {
+      await this.indexManager.addPhoto({ id, importedAt, sourceType: "google_drive" });
+    } catch (err) {
+      await this.client.deleteFile(created.id).catch(() => {});
+      throw err;
+    }
 
     return photo;
   }

--- a/src/lib/photo-importer.ts
+++ b/src/lib/photo-importer.ts
@@ -1,4 +1,5 @@
 import { DriveClient } from "./drive-client";
+import { DriveNotFoundError } from "./drive-errors";
 import { IndexManager } from "./index-manager";
 import type { PhotoObject } from "@/types/photo";
 import type { PhotoSourceType } from "@/types/settings";
@@ -112,7 +113,10 @@ export class PhotoImporter {
   ): Promise<GooglePhotosSearchResult> {
     const { startDate, endDate, keyword, pageSize = 50, pageToken } = options;
 
-    const filters: Record<string, unknown> = {};
+    const filters: Record<string, unknown> = {
+      // 動画を除外して写真のみ返す
+      mediaTypeFilter: { mediaTypes: ["PHOTO"] },
+    };
 
     if (startDate || endDate) {
       filters.dateFilter = {
@@ -127,7 +131,7 @@ export class PhotoImporter {
 
     const body: Record<string, unknown> = {
       pageSize,
-      filters: Object.keys(filters).length > 0 ? filters : undefined,
+      filters,
     };
     if (pageToken) body.pageToken = pageToken;
 
@@ -277,9 +281,13 @@ export class PhotoImporter {
   async deletePhoto(id: string): Promise<void> {
     await this.ensureIndexLoaded();
 
-    const file = await this.client
-      .findAppDataFileByName(photoFileName(id))
-      .catch(() => null);
+    let file = null;
+    try {
+      file = await this.client.findAppDataFileByName(photoFileName(id));
+    } catch (err) {
+      // ファイルが存在しない場合のみ null 扱い。その他のエラーは再スロー
+      if (!(err instanceof DriveNotFoundError)) throw err;
+    }
     if (file) {
       await this.client.deleteFile(file.id);
     }

--- a/src/lib/photo-importer.ts
+++ b/src/lib/photo-importer.ts
@@ -1,0 +1,266 @@
+import { DriveClient } from "./drive-client";
+import { IndexManager } from "./index-manager";
+import type { PhotoObject } from "@/types/photo";
+import type { PhotoSourceType } from "@/types/settings";
+
+const PHOTO_FILE_PREFIX = "photo_";
+
+function photoFileName(id: string): string {
+  return `${PHOTO_FILE_PREFIX}${id}.json`;
+}
+
+/** Google Photos API のメディアアイテム（必要フィールドのみ）。 */
+export type GooglePhotosMediaItem = {
+  id: string;
+  filename: string;
+  mediaMetadata: {
+    creationTime?: string;
+    width?: string;
+    height?: string;
+    photo?: Record<string, unknown>;
+  };
+  baseUrl: string;
+};
+
+/** Google Photos 検索オプション。 */
+export type GooglePhotosSearchOptions = {
+  /** 絞り込む開始日（ISO 8601 形式）。 */
+  startDate?: string;
+  /** 絞り込む終了日（ISO 8601 形式）。 */
+  endDate?: string;
+  /** 1ページあたりの件数（最大 100）。 */
+  pageSize?: number;
+  pageToken?: string;
+};
+
+export type GooglePhotosSearchResult = {
+  mediaItems: GooglePhotosMediaItem[];
+  nextPageToken?: string;
+};
+
+/** Google Drive の画像ファイル検索結果。 */
+export type DriveImageFile = {
+  id: string;
+  name: string;
+  mimeType: string;
+  thumbnailLink?: string;
+  createdTime?: string;
+  modifiedTime?: string;
+};
+
+export type DriveImageSearchResult = {
+  files: DriveImageFile[];
+  nextPageToken?: string;
+};
+
+const PHOTOS_API_BASE = "https://photoslibrary.googleapis.com/v1";
+
+/**
+ * Google Photos / Google Drive から写真を検索し、
+ * PhotoObject として appDataFolder に保存するクラス。
+ */
+export class PhotoImporter {
+  private readonly client: DriveClient;
+  private readonly indexManager: IndexManager;
+  private readonly accessToken: string;
+
+  constructor(
+    client: DriveClient,
+    indexManager: IndexManager,
+    accessToken: string,
+  ) {
+    this.client = client;
+    this.indexManager = indexManager;
+    this.accessToken = accessToken;
+  }
+
+  // ------------------------------------------------------------------
+  // Google Photos 検索
+  // ------------------------------------------------------------------
+
+  /** Google Photos からメディアアイテムを検索する。 */
+  async searchGooglePhotos(
+    options: GooglePhotosSearchOptions = {},
+  ): Promise<GooglePhotosSearchResult> {
+    const { startDate, endDate, pageSize = 50, pageToken } = options;
+
+    const filters: Record<string, unknown> = {};
+
+    if (startDate || endDate) {
+      const parseDate = (iso: string) => {
+        const d = new Date(iso);
+        return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
+      };
+      filters.dateFilter = {
+        ranges: [
+          {
+            ...(startDate ? { startDate: parseDate(startDate) } : {}),
+            ...(endDate ? { endDate: parseDate(endDate) } : {}),
+          },
+        ],
+      };
+    }
+
+    const body: Record<string, unknown> = {
+      pageSize,
+      filters: Object.keys(filters).length > 0 ? filters : undefined,
+    };
+    if (pageToken) body.pageToken = pageToken;
+
+    const res = await fetch(`${PHOTOS_API_BASE}/mediaItems:search`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(
+        `Google Photos API error ${res.status}: ${JSON.stringify(err)}`,
+      );
+    }
+
+    const data = await res.json();
+    return {
+      mediaItems: data.mediaItems ?? [],
+      nextPageToken: data.nextPageToken,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Google Drive 画像検索
+  // ------------------------------------------------------------------
+
+  /** Google Drive から画像ファイルを検索する。 */
+  async searchDriveImages(options: {
+    keyword?: string;
+    pageSize?: number;
+    pageToken?: string;
+  } = {}): Promise<DriveImageSearchResult> {
+    const { keyword, pageSize = 50, pageToken } = options;
+
+    const mimeFilter =
+      "(mimeType contains 'image/') and trashed = false";
+    const keywordFilter = keyword
+      ? ` and name contains '${keyword.replace(/'/g, "\\'")}'`
+      : "";
+    const query = encodeURIComponent(mimeFilter + keywordFilter);
+
+    const pageParam = pageToken
+      ? `&pageToken=${encodeURIComponent(pageToken)}`
+      : "";
+
+    const fields = encodeURIComponent(
+      "nextPageToken,files(id,name,mimeType,thumbnailLink,createdTime,modifiedTime)",
+    );
+
+    const url =
+      `https://www.googleapis.com/drive/v3/files?q=${query}&spaces=drive` +
+      `&fields=${fields}&pageSize=${pageSize}&orderBy=createdTime+desc${pageParam}`;
+
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: "application/json",
+      },
+    });
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(
+        `Drive API error ${res.status}: ${JSON.stringify(err)}`,
+      );
+    }
+
+    const data = await res.json();
+    return {
+      files: data.files ?? [],
+      nextPageToken: data.nextPageToken,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // 写真インポート
+  // ------------------------------------------------------------------
+
+  /** Google Photos のメディアアイテムを PhotoObject として保存する。 */
+  async importFromGooglePhotos(
+    item: GooglePhotosMediaItem,
+  ): Promise<PhotoObject> {
+    const id = crypto.randomUUID();
+    const importedAt = new Date().toISOString();
+
+    const photo: PhotoObject = {
+      id,
+      importedAt,
+      sourceType: "google_photos" as PhotoSourceType,
+      sourceRef: item.id,
+      title: item.filename,
+      takenAt: item.mediaMetadata.creationTime,
+    };
+
+    await this.client.createAppDataFile(photoFileName(id), photo);
+    await this.indexManager.addPhoto({ id, importedAt, sourceType: "google_photos" });
+
+    return photo;
+  }
+
+  /** Google Drive の画像ファイルを PhotoObject として保存する。 */
+  async importFromGoogleDrive(file: DriveImageFile): Promise<PhotoObject> {
+    const id = crypto.randomUUID();
+    const importedAt = new Date().toISOString();
+
+    const photo: PhotoObject = {
+      id,
+      importedAt,
+      sourceType: "google_drive" as PhotoSourceType,
+      sourceRef: file.id,
+      title: file.name,
+      takenAt: file.createdTime,
+    };
+
+    await this.client.createAppDataFile(photoFileName(id), photo);
+    await this.indexManager.addPhoto({ id, importedAt, sourceType: "google_drive" });
+
+    return photo;
+  }
+
+  /** PhotoObject を appDataFolder から読み込む。 */
+  async loadPhoto(id: string): Promise<PhotoObject> {
+    return this.client.getAppDataFileByName<PhotoObject>(photoFileName(id)).then(
+      ({ _fileId: _, _file: __, ...photo }) => photo as PhotoObject,
+    );
+  }
+
+  /** PhotoObject を削除する（appDataFolder のファイルと index から）。 */
+  async deletePhoto(id: string): Promise<void> {
+    const file = await this.client
+      .findAppDataFileByName(photoFileName(id))
+      .catch(() => null);
+    if (file) {
+      await this.client.deleteFile(file.id);
+    }
+    await this.indexManager.removePhoto(id);
+  }
+
+  /** PhotoObject の cropRect などを更新して保存する。 */
+  async updatePhoto(photo: PhotoObject): Promise<void> {
+    const file = await this.client.findAppDataFileByName(photoFileName(photo.id));
+    await this.client.updateFileContent(file.id, photo);
+  }
+
+  /**
+   * Google Photos のベース URL からサムネイル URL を生成する。
+   * baseUrl に `=w<width>-h<height>` を付与するとリサイズされた画像が得られる。
+   */
+  static getThumbnailUrl(
+    baseUrl: string,
+    width = 256,
+    height = 256,
+  ): string {
+    return `${baseUrl}=w${width}-h${height}`;
+  }
+}

--- a/src/lib/photo-importer.ts
+++ b/src/lib/photo-importer.ts
@@ -9,6 +9,21 @@ function photoFileName(id: string): string {
   return `${PHOTO_FILE_PREFIX}${id}.json`;
 }
 
+/** Drive クエリ文字列値をエスケープする（`\` と `'`）。 */
+function escapeDriveQueryValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+/**
+ * ISO 8601 の日付文字列（YYYY-MM-DD または YYYY-MM-DDTHH:mm:ssZ）を
+ * タイムゾーン非依存で year/month/day オブジェクトに変換する。
+ */
+function parseIsoDateToYMD(iso: string): { year: number; month: number; day: number } {
+  const datePart = iso.split("T")[0];
+  const [year, month, day] = datePart.split("-").map(Number);
+  return { year, month, day };
+}
+
 /** Google Photos API のメディアアイテム（必要フィールドのみ）。 */
 export type GooglePhotosMediaItem = {
   id: string;
@@ -24,10 +39,12 @@ export type GooglePhotosMediaItem = {
 
 /** Google Photos 検索オプション。 */
 export type GooglePhotosSearchOptions = {
-  /** 絞り込む開始日（ISO 8601 形式）。 */
+  /** 絞り込む開始日（YYYY-MM-DD または ISO 8601 形式）。 */
   startDate?: string;
-  /** 絞り込む終了日（ISO 8601 形式）。 */
+  /** 絞り込む終了日（YYYY-MM-DD または ISO 8601 形式）。 */
   endDate?: string;
+  /** ファイル名部分一致フィルタ（クライアントサイドで適用）。 */
+  keyword?: string;
   /** 1ページあたりの件数（最大 100）。 */
   pageSize?: number;
   pageToken?: string;
@@ -58,11 +75,14 @@ const PHOTOS_API_BASE = "https://photoslibrary.googleapis.com/v1";
 /**
  * Google Photos / Google Drive から写真を検索し、
  * PhotoObject として appDataFolder に保存するクラス。
+ *
+ * IndexManager は初回操作時に自動で load() される。
  */
 export class PhotoImporter {
   private readonly client: DriveClient;
   private readonly indexManager: IndexManager;
   private readonly accessToken: string;
+  private indexLoaded = false;
 
   constructor(
     client: DriveClient,
@@ -74,6 +94,14 @@ export class PhotoImporter {
     this.accessToken = accessToken;
   }
 
+  /** IndexManager が未ロードなら load() を呼ぶ。 */
+  private async ensureIndexLoaded(): Promise<void> {
+    if (!this.indexLoaded) {
+      await this.indexManager.load();
+      this.indexLoaded = true;
+    }
+  }
+
   // ------------------------------------------------------------------
   // Google Photos 検索
   // ------------------------------------------------------------------
@@ -82,20 +110,16 @@ export class PhotoImporter {
   async searchGooglePhotos(
     options: GooglePhotosSearchOptions = {},
   ): Promise<GooglePhotosSearchResult> {
-    const { startDate, endDate, pageSize = 50, pageToken } = options;
+    const { startDate, endDate, keyword, pageSize = 50, pageToken } = options;
 
     const filters: Record<string, unknown> = {};
 
     if (startDate || endDate) {
-      const parseDate = (iso: string) => {
-        const d = new Date(iso);
-        return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() };
-      };
       filters.dateFilter = {
         ranges: [
           {
-            ...(startDate ? { startDate: parseDate(startDate) } : {}),
-            ...(endDate ? { endDate: parseDate(endDate) } : {}),
+            ...(startDate ? { startDate: parseIsoDateToYMD(startDate) } : {}),
+            ...(endDate ? { endDate: parseIsoDateToYMD(endDate) } : {}),
           },
         ],
       };
@@ -124,8 +148,18 @@ export class PhotoImporter {
     }
 
     const data = await res.json();
+    let mediaItems: GooglePhotosMediaItem[] = data.mediaItems ?? [];
+
+    // Google Photos API にファイル名検索がないため、クライアント側でフィルタする
+    if (keyword) {
+      const lower = keyword.toLowerCase();
+      mediaItems = mediaItems.filter((item) =>
+        item.filename.toLowerCase().includes(lower),
+      );
+    }
+
     return {
-      mediaItems: data.mediaItems ?? [],
+      mediaItems,
       nextPageToken: data.nextPageToken,
     };
   }
@@ -145,7 +179,7 @@ export class PhotoImporter {
     const mimeFilter =
       "(mimeType contains 'image/') and trashed = false";
     const keywordFilter = keyword
-      ? ` and name contains '${keyword.replace(/'/g, "\\'")}'`
+      ? ` and name contains '${escapeDriveQueryValue(keyword)}'`
       : "";
     const query = encodeURIComponent(mimeFilter + keywordFilter);
 
@@ -190,6 +224,8 @@ export class PhotoImporter {
   async importFromGooglePhotos(
     item: GooglePhotosMediaItem,
   ): Promise<PhotoObject> {
+    await this.ensureIndexLoaded();
+
     const id = crypto.randomUUID();
     const importedAt = new Date().toISOString();
 
@@ -210,6 +246,8 @@ export class PhotoImporter {
 
   /** Google Drive の画像ファイルを PhotoObject として保存する。 */
   async importFromGoogleDrive(file: DriveImageFile): Promise<PhotoObject> {
+    await this.ensureIndexLoaded();
+
     const id = crypto.randomUUID();
     const importedAt = new Date().toISOString();
 
@@ -237,6 +275,8 @@ export class PhotoImporter {
 
   /** PhotoObject を削除する（appDataFolder のファイルと index から）。 */
   async deletePhoto(id: string): Promise<void> {
+    await this.ensureIndexLoaded();
+
     const file = await this.client
       .findAppDataFileByName(photoFileName(id))
       .catch(() => null);
@@ -262,5 +302,18 @@ export class PhotoImporter {
     height = 256,
   ): string {
     return `${baseUrl}=w${width}-h${height}`;
+  }
+
+  /**
+   * Drive の thumbnailLink を Authorization ヘッダ付きで取得し Blob URL を返す。
+   * Drive サムネイルはサードパーティ Cookie 制限下で img src に直接使えないことがあるため。
+   */
+  async fetchDriveThumbnailBlobUrl(thumbnailLink: string): Promise<string> {
+    const res = await fetch(thumbnailLink, {
+      headers: { Authorization: `Bearer ${this.accessToken}` },
+    });
+    if (!res.ok) throw new Error(`thumbnail fetch failed: ${res.status}`);
+    const blob = await res.blob();
+    return URL.createObjectURL(blob);
   }
 }

--- a/src/lib/photo-importer.ts
+++ b/src/lib/photo-importer.ts
@@ -24,18 +24,18 @@ function parseIsoDateToYMD(iso: string): { year: number; month: number; day: num
   const datePart = iso.split("T")[0];
   const parts = datePart.split("-");
   if (parts.length !== 3) {
-    throw new Error(`Invalid date format: "${iso}". Expected YYYY-MM-DD.`);
+    throw new Error(`日付の形式が正しくありません: "${iso}"（YYYY-MM-DD 形式で入力してください）。`);
   }
   const [year, month, day] = parts.map(Number);
   if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day) ||
       month < 1 || month > 12 || day < 1 || day > 31) {
-    throw new Error(`Invalid date value: "${iso}".`);
+    throw new Error(`日付の値が不正です: "${iso}"（月は 1〜12、日は 1〜31 の範囲で指定してください）。`);
   }
   // Date.UTC で実在日付かどうかを検証（例: 2026-02-31 は 3 月に繰り越される）
   const utc = Date.UTC(year, month - 1, day);
   const d = new Date(utc);
   if (d.getUTCFullYear() !== year || d.getUTCMonth() + 1 !== month || d.getUTCDate() !== day) {
-    throw new Error(`Date does not exist: "${iso}".`);
+    throw new Error(`存在しない日付です: "${iso}"（${month} 月に ${day} 日はありません）。`);
   }
   return { year, month, day };
 }
@@ -99,6 +99,7 @@ export class PhotoImporter {
   private readonly indexManager: IndexManager;
   private readonly accessToken: string;
   private indexLoaded = false;
+  private indexLoadPromise: Promise<void> | null = null;
 
   constructor(
     client: DriveClient,
@@ -110,12 +111,15 @@ export class PhotoImporter {
     this.accessToken = accessToken;
   }
 
-  /** IndexManager が未ロードなら load() を呼ぶ。 */
-  private async ensureIndexLoaded(): Promise<void> {
-    if (!this.indexLoaded) {
-      await this.indexManager.load();
-      this.indexLoaded = true;
+  /** IndexManager が未ロードなら load() を呼ぶ。並行呼び出しでも load() は1回だけ実行される。 */
+  private ensureIndexLoaded(): Promise<void> {
+    if (this.indexLoaded) return Promise.resolve();
+    if (!this.indexLoadPromise) {
+      this.indexLoadPromise = this.indexManager.load().then(() => {
+        this.indexLoaded = true;
+      });
     }
+    return this.indexLoadPromise;
   }
 
   // ------------------------------------------------------------------

--- a/src/types/photo.ts
+++ b/src/types/photo.ts
@@ -1,5 +1,15 @@
-import type { CropRect } from "./scan";
 import type { PhotoSourceType } from "./settings";
+
+/**
+ * 写真の切り抜き矩形。PhotoObject 専用の正規化座標（0..1）。
+ * scan.ts の CropRect（ピクセル単位）とは別の型。
+ */
+export type NormalizedCropRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
 
 /** Google Photos または Google Drive から取り込んだ写真オブジェクト。 */
 export type PhotoObject = {
@@ -9,5 +19,6 @@ export type PhotoObject = {
   sourceRef: string;
   title?: string;
   takenAt?: string;
-  cropRect?: CropRect;
+  /** 切り抜き矩形（正規化座標 0..1）。 */
+  cropRect?: NormalizedCropRect;
 };


### PR DESCRIPTION
## Summary

Closes #19

- **`src/lib/photo-importer.ts`** — `PhotoImporter` クラスを新規追加。Google Photos API（`mediaItems:search`）と Google Drive API の両方から画像を検索し、選択した写真を `PhotoObject` として appDataFolder に保存、`IndexManager` にも登録する。
- **`src/components/PhotoPicker.tsx`** — タブ切り替えで Google Photos / Google Drive を検索・インポートできる UI コンポーネント。日付範囲・キーワードフィルタ、ページネーション対応。
- **`src/components/PhotoCard.tsx`** — 写真1件を表示するカードコンポーネント。サムネイル・撮影日時・ソース種別を表示し、マウスドラッグによる正規化座標（0..1）の `cropRect` 選択 UI を持つ。
- **`src/types/photo.ts`** — `NormalizedCropRect`（0..1 正規化座標）型を追加し、`PhotoObject.cropRect` に適用（ピクセル単位の `CropRect` と分離）。
- **`src/lib/auth-context.tsx`** — ログイン時の OAuth スコープに以下を追加:
  - `https://www.googleapis.com/auth/photoslibrary.readonly` — Google Photos API 利用に必要
  - `https://www.googleapis.com/auth/drive.metadata.readonly` — Google Drive 全体の画像ファイル検索に必要（`drive.file` スコープはアプリ作成ファイルのみ対象のため）

## Test plan

- [ ] Google アカウントでログインし、Photos / Drive metadata スコープの同意画面が表示されることを確認
- [ ] PhotoPicker の Google Photos タブで日付範囲・キーワードを指定して検索し、サムネイルが表示されることを確認
- [ ] Google Photos タブで「インポート」を押すと PhotoObject が appDataFolder に保存されることを確認（Drive appData に `photo_<uuid>.json` が作成される）
- [ ] IndexManager の `getPhotos()` に新しいエントリが追加されることを確認
- [ ] PhotoPicker の Google Drive タブで画像ファイルを検索・インポートできることを確認
- [ ] PhotoCard の切り抜き UI でドラッグ選択 → 適用 → `cropRect` が更新されることを確認

https://claude.ai/code/session_0134pkKriwjXdVU8kQ6piuVC